### PR TITLE
Chore: Batch reporting for Graphite

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -159,16 +159,24 @@ const { Metrics, GraphiteReporter } = require('metrics-reporter');
 const graphiteHost = '1.1.1.1';         // Graphite server IP address
 const graphitePort = 8125;              // Optional - port number. Defaults to 8125
 const spacePrefix = 'My.Project';       // Optional - prefix to all metrics spaces
-const tags = { tag1: 'value1' };        // Optional - key-value pairs to be appanded to all the metrics reported 
+const tags = { tag1: 'value1' };        // Optional - key-value pairs to be appanded to all the metrics reported
+const batch = true;                     // Optional - Default `true` - Indicates that metrics will be sent in batches
+const maxBufferSize = 500;              // Optional - Default `1000` - Size of the buffer for sending batched messages. When buffer is filled it is flushed immediately
+const flushInterval = 1000;             // Optional - Default `1000` (1s) - Time in milliseconds. Indicates how often the buffer is flushed in case batch = true
 
 const graphiteReporter = new GraphiteReporter({
 		host: graphiteHost,
 		port: graphitePort,
 		prefix: spacePrefix,
 		tags,
+    batch,
+    maxBufferSize,
+    flushInterval,
 	});
 
 const metrics = new Metrics([graphiteReporter], errorCallback);
+
+graphiteReporter.close(); // close should be called when the application terminates
 ```
 
 #### DataDog

--- a/examples/graphite.js
+++ b/examples/graphite.js
@@ -30,4 +30,6 @@ function timeout(ms) {
     // eslint-disable-next-line no-await-in-loop
     await timeout(10);
   }
+
+  await timeout(10000);
 })();

--- a/network/socket.js
+++ b/network/socket.js
@@ -1,6 +1,6 @@
 const dgram = require('dgram');
 
-module.exports = function Socket({
+function Socket({
   port, host, batch = true, maxBufferSize = 1000, flushInterval = 1000,
 }) {
   if (!port) {
@@ -89,4 +89,8 @@ module.exports = function Socket({
       callback();
     });
   }
+}
+
+module.exports = {
+  Socket,
 };

--- a/network/socket.js
+++ b/network/socket.js
@@ -3,12 +3,11 @@ const dgram = require('dgram');
 function Socket({
   port, host, batch = true, maxBufferSize = 1000, flushInterval = 1000,
 }) {
-  if (!port) {
-    throw new TypeError('port is mandatory');
-  }
-  if (!host) {
-    throw new TypeError('host is mandatory');
-  }
+  validate({ name: 'port', value: port, type: 'number' });
+  validate({ name: 'host', value: host, type: 'string' });
+  validate({ name: 'batch', value: batch, type: 'boolean' });
+  validate({ name: 'maxBufferSize', value: maxBufferSize, type: 'number' });
+  validate({ name: 'flushInterval', value: flushInterval, type: 'number' });
 
   const socket = dgram.createSocket('udp4');
   socket.unref();
@@ -89,6 +88,12 @@ function Socket({
       callback();
     });
   }
+}
+
+function validate({ name, value, type }) {
+  if (value === undefined || value === null) throw new TypeError(`${name} is missing`);
+  // eslint-disable-next-line valid-typeof
+  if (typeof value !== type) throw new TypeError(`${name} is not a ${type}: ${value}: ${typeof value}`);
 }
 
 module.exports = {

--- a/network/socket.test.js
+++ b/network/socket.test.js
@@ -4,24 +4,90 @@ const { Socket } = require('./socket');
 
 jest.mock('dgram');
 
-describe('socket', () => {
+describe('Socket', () => {
   describe('constructor', () => {
-    it.each([undefined, null])('should throw when port is %s', port => {
-      stubCreateSocket();
+    describe('validations', () => {
+      it.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['string', 'strings'],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+        ['function', () => {}]])('should throw when port is %s', (title, port) => {
+        stubCreateSocket();
 
-      expect(() => new Socket({
-        host: '127.0.0.1',
-        port,
-      })).toThrow(TypeError);
-    });
+        expect(() => new Socket({
+          host: '127.0.0.1',
+          port,
+        })).toThrow(TypeError);
+      });
 
-    it.each([undefined, null])('should throw when host is %s', host => {
-      stubCreateSocket();
+      it.each([
+        ['undefined', undefined],
+        ['null', null],
+        ['number', 1],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+        ['function', () => {}],
+      ])('should throw when host is %s', (title, host) => {
+        stubCreateSocket();
 
-      expect(() => new Socket({
-        port: 1234,
-        host,
-      })).toThrow(TypeError);
+        expect(() => new Socket({
+          port: 1234,
+          host,
+        })).toThrow(TypeError);
+      });
+
+      it.each([
+        ['null', null],
+        ['number', 1],
+        ['string', 'strings'],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+        ['function', () => {}],
+      ])('should throw when batch is %s', (title, batch) => {
+        stubCreateSocket();
+
+        expect(() => new Socket({
+          port: 1234,
+          host: '127.0.0.1',
+          batch,
+        })).toThrow(TypeError);
+      });
+
+      it.each([
+        ['null', null],
+        ['boolean', true],
+        ['string', 'strings'],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+        ['function', () => {}],
+      ])('should throw when maxBufferSize is %s', (title, maxBufferSize) => {
+        stubCreateSocket();
+
+        expect(() => new Socket({
+          port: 1234,
+          host: '127.0.0.1',
+          maxBufferSize,
+        })).toThrow(TypeError);
+      });
+
+      it.each([
+        ['null', null],
+        ['boolean', true],
+        ['string', 'strings'],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+        ['function', () => {}],
+      ])('should throw when flushInterval is %s', (title, flushInterval) => {
+        stubCreateSocket();
+
+        expect(() => new Socket({
+          port: 1234,
+          host: '127.0.0.1',
+          flushInterval,
+        })).toThrow(TypeError);
+      });
     });
 
     it('should create a socket', () => {

--- a/network/socket.test.js
+++ b/network/socket.test.js
@@ -1,6 +1,6 @@
 const dgram = require('dgram');
 const { when } = require('jest-when');
-const Socket = require('./socket');
+const { Socket } = require('./socket');
 
 jest.mock('dgram');
 

--- a/network/statsd-socket.js
+++ b/network/statsd-socket.js
@@ -34,7 +34,7 @@ function StatsdSocket({
   }
 
   function validate({ name, value, type }) {
-    if (!value) throw new TypeError(`${name} is missing`);
+    if (value === undefined || value === null) throw new TypeError(`${name} is missing`);
     // eslint-disable-next-line valid-typeof
     if (typeof value !== type) throw new TypeError(`${name} is not a ${type}: ${value}: ${typeof value}`);
   }

--- a/network/statsd-socket.js
+++ b/network/statsd-socket.js
@@ -1,13 +1,20 @@
 const { Socket } = require('./socket');
 
+const redundantDotsRegex = new RegExp('\\.\\.+', 'g');
+
 function StatsdSocket({
-  port,
+  port = 8125,
   host,
   batch = true,
   maxBufferSize = 1000,
   flushInterval = 1000,
-  defaultTags,
+  tags: defaultTags,
+  prefix,
 }) {
+  if (defaultTags && (Array.isArray(defaultTags) || typeof defaultTags !== 'object')) throw new TypeError('tags should be an object');
+
+  const metricPrefix = typeof prefix === 'string' && prefix.length ? removeRedundantDots(`${prefix}.`) : '';
+
   const socket = new Socket({
     host, port, batch, maxBufferSize, flushInterval,
   });
@@ -15,17 +22,48 @@ function StatsdSocket({
   function send({
     key, value, type, tags, callback,
   }) {
+    validate({ name: 'key', value: key, type: 'string' });
+    validate({ name: 'value', value, type: 'number' });
+    validate({ name: 'type', value: type, type: 'string' });
+    if (tags && (Array.isArray(tags) || typeof tags !== 'object')) throw new TypeError('tags should be an object');
+    if (callback && typeof callback !== 'function') throw new TypeError('callback should be a function');
 
+    const metric = `${metricPrefix}${key}:${value}|${type}${stringifyTags(tags)}`;
+
+    socket.send({ message: metric, callback });
+  }
+
+  function validate({ name, value, type }) {
+    if (!value) throw new TypeError(`${name} is missing`);
+    // eslint-disable-next-line valid-typeof
+    if (typeof value !== type) throw new TypeError(`${name} is not a ${type}: ${value}: ${typeof value}`);
   }
 
   function close() {
+    socket.close();
+  }
 
+  function stringifyTags(tags) {
+    if (!tags && !defaultTags) {
+      return '';
+    }
+
+    const allTags = {
+      ...defaultTags,
+      ...tags,
+    };
+
+    return `|#${Object.entries(allTags).map(([key, value]) => `${key}:${value}`).join(',')}`;
   }
 
   return {
     send,
     close,
   };
+}
+
+function removeRedundantDots(str) {
+  return str.replace(redundantDotsRegex, '.');
 }
 
 module.exports = {

--- a/network/statsd-socket.js
+++ b/network/statsd-socket.js
@@ -34,7 +34,7 @@ function StatsdSocket({
   }
 
   function validate({ name, value, type }) {
-    if (value === undefined || value === null) throw new TypeError(`${name} is missing`);
+    if (value === undefined || value === null || (typeof value === 'string' && value === '')) throw new TypeError(`${name} is missing`);
     // eslint-disable-next-line valid-typeof
     if (typeof value !== type) throw new TypeError(`${name} is not a ${type}: ${value}: ${typeof value}`);
   }

--- a/network/statsd-socket.js
+++ b/network/statsd-socket.js
@@ -1,0 +1,33 @@
+const { Socket } = require('./socket');
+
+function StatsdSocket({
+  port,
+  host,
+  batch = true,
+  maxBufferSize = 1000,
+  flushInterval = 1000,
+  defaultTags,
+}) {
+  const socket = new Socket({
+    host, port, batch, maxBufferSize, flushInterval,
+  });
+
+  function send({
+    key, value, type, tags, callback,
+  }) {
+
+  }
+
+  function close() {
+
+  }
+
+  return {
+    send,
+    close,
+  };
+}
+
+module.exports = {
+  StatsdSocket,
+};

--- a/network/statsd-socket.test.js
+++ b/network/statsd-socket.test.js
@@ -1,5 +1,330 @@
+jest.mock('./socket', () => ({ Socket: jest.fn() }));
+const { Socket } = require('./socket');
 const { StatsdSocket } = require('./statsd-socket');
 
-jest.mock('./socket', () => {
+describe('StatsdSocket', () => {
+  describe('constructor', () => {
+    it('should create socket with given host and default values', () => {
+      // eslint-disable-next-line no-new
+      new StatsdSocket({
+        host: '127.0.0.1',
+      });
 
+      expect(Socket).toBeCalledWith({
+        host: '127.0.0.1',
+        port: 8125,
+        batch: true,
+        maxBufferSize: 1000,
+        flushInterval: 1000,
+      });
+    });
+
+    it('should create socket with given values', () => {
+      // eslint-disable-next-line no-new
+      new StatsdSocket({
+        host: '127.0.0.1',
+        port: 1234,
+        batch: false,
+        maxBufferSize: 10,
+        flushInterval: 20,
+      });
+
+      expect(Socket).toBeCalledWith({
+        host: '127.0.0.1',
+        port: 1234,
+        batch: false,
+        maxBufferSize: 10,
+        flushInterval: 20,
+      });
+    });
+
+    it.each([
+      ['string', 'strings'],
+      ['number', 1],
+      ['array', ['a', 'b']],
+    ])('should throw when default tags are %s', (title, tags) => {
+      expect(() => {
+        // eslint-disable-next-line no-new
+        new StatsdSocket({
+          host: '127.0.0.1',
+          tags,
+        });
+      }).toThrow(TypeError);
+    });
+  });
+
+  describe('close', () => {
+    it('should close socket', () => {
+      const { close } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+      });
+
+      target.close();
+
+      expect(close).toBeCalledTimes(1);
+    });
+  });
+
+  describe('send', () => {
+    describe('validations', () => {
+      it.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['empty string', ''],
+        ['number', 1],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+      ])('should throw when key is %s', (title, key) => {
+        setSocket();
+
+        const target = new StatsdSocket({
+          host: '127.0.0.1',
+        });
+
+        expect(() => target.send({
+          key,
+          value: 1.2,
+          type: 'ms',
+        })).toThrow(TypeError);
+      });
+
+      it.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['string', 'no string on me'],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+      ])('should throw when value is %s', (title, value) => {
+        setSocket();
+
+        const target = new StatsdSocket({
+          host: '127.0.0.1',
+        });
+
+        expect(() => target.send({
+          key: 'space.the.final.frontier',
+          value,
+          type: 'ms',
+        })).toThrow(TypeError);
+      });
+
+      it.each([
+        ['null', null],
+        ['undefined', undefined],
+        ['empty string', ''],
+        ['number', 1],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+      ])('should throw when type is %s', (title, type) => {
+        setSocket();
+
+        const target = new StatsdSocket({
+          host: '127.0.0.1',
+        });
+
+        expect(() => target.send({
+          key: 'space.the.final.frontier',
+          value: 1.2,
+          type,
+        })).toThrow(TypeError);
+      });
+
+      it.each([
+        ['string', 'a string'],
+        ['number', 1],
+        ['array', ['a', 'b']],
+      ])('should throw when tags is %s', (title, tags) => {
+        setSocket();
+
+        const target = new StatsdSocket({
+          host: '127.0.0.1',
+        });
+
+        expect(() => target.send({
+          key: 'space.the.final.frontier',
+          value: 1.2,
+          type: 'ms',
+          tags,
+        })).toThrow(TypeError);
+      });
+
+      it.each([
+        ['string', 'a string'],
+        ['number', 1],
+        ['array', ['a', 'b']],
+        ['object', { key: 'value' }],
+      ])('should throw when callback is %s', (title, callback) => {
+        setSocket();
+
+        const target = new StatsdSocket({
+          host: '127.0.0.1',
+        });
+
+        expect(() => target.send({
+          key: 'space.the.final.frontier',
+          value: 1.2,
+          type: 'ms',
+          callback,
+        })).toThrow(TypeError);
+      });
+    });
+
+    it('should send metric', () => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+      });
+
+      expect(send).toBeCalledWith({ message: 'space.subspace:1|ms' });
+    });
+
+    it('should send callback when defined', () => {
+      const { send } = setSocket();
+      const callback = () => {};
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+        callback,
+      });
+
+      expect(send).toBeCalledWith({ message: 'space.subspace:1|ms', callback });
+    });
+
+    it('should append prefix if defined', () => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+        prefix: 'namespace.prefix.',
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+      });
+
+      expect(send).toBeCalledWith({ message: 'namespace.prefix.space.subspace:1|ms' });
+    });
+
+    it('should append prefix if defined without trailing dots', () => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+        prefix: 'namespace.prefix',
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+      });
+
+      expect(send).toBeCalledWith({ message: 'namespace.prefix.space.subspace:1|ms' });
+    });
+
+    it.each([
+      ['null', null],
+      ['undefined', undefined],
+      ['empty string', ''],
+      ['number', 1],
+      ['array', ['a', 'b']],
+      ['object', { key: 'value' }],
+    ])('should ignore prefix if it is %s', (title, prefix) => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+        prefix,
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+      });
+
+      expect(send).toBeCalledWith({ message: 'space.subspace:1|ms' });
+    });
+
+    it('should append tags', () => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+        tags: { tag1: 'value1', tag2: 'value2' },
+      });
+
+      expect(send).toBeCalledWith({ message: 'space.subspace:1|ms|#tag1:value1,tag2:value2' });
+    });
+
+    it('should append default tags', () => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+        tags: { tag1: 'value1', tag2: 'value2' },
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+      });
+
+      expect(send).toBeCalledWith({ message: 'space.subspace:1|ms|#tag1:value1,tag2:value2' });
+    });
+
+    it('should merge tags and default tags', () => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+        tags: { tag1: 'value1', tag2: 'value2' },
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 1,
+        type: 'ms',
+        tags: { tag2: 'overridden', tag3: 'value3' },
+      });
+
+      expect(send).toBeCalledWith({ message: 'space.subspace:1|ms|#tag1:value1,tag2:overridden,tag3:value3' });
+    });
+  });
+
+  function setSocket() {
+    const close = jest.fn();
+    const send = jest.fn();
+
+    Socket.mockImplementationOnce(() => ({ close, send }));
+
+    return {
+      close,
+      send,
+    };
+  }
 });

--- a/network/statsd-socket.test.js
+++ b/network/statsd-socket.test.js
@@ -1,0 +1,5 @@
+const { StatsdSocket } = require('./statsd-socket');
+
+jest.mock('./socket', () => {
+
+});

--- a/network/statsd-socket.test.js
+++ b/network/statsd-socket.test.js
@@ -187,6 +187,22 @@ describe('StatsdSocket', () => {
       expect(send).toBeCalledWith({ message: 'space.subspace:1|ms' });
     });
 
+    it('should send metric when value is 0', () => {
+      const { send } = setSocket();
+
+      const target = new StatsdSocket({
+        host: '127.0.0.1',
+      });
+
+      target.send({
+        key: 'space.subspace',
+        value: 0,
+        type: 'ms',
+      });
+
+      expect(send).toBeCalledWith({ message: 'space.subspace:0|ms' });
+    });
+
     it('should send callback when defined', () => {
       const { send } = setSocket();
       const callback = () => {};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "datadog",
     "DogStatsD"
   ],
-  "version": "0.9.0",
+  "version": "0.10.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ysa23/metrics-js"

--- a/reporters/datadog-reporter.js
+++ b/reporters/datadog-reporter.js
@@ -13,25 +13,32 @@ module.exports = function DataDogReporter({
     port, host, batch, maxBufferSize, flushInterval, prefix, tags: defaultTags,
   });
 
-  this.report = (key, value, tags, errorCallback) => {
+  function report(key, value, tags, errorCallback) {
     socket.send({
       key, value, type: 'ms', tags, callback: errorCallback,
     });
-  };
+  }
 
-  this.value = (key, value, tags, errorCallback) => {
+  function _value(key, value, tags, errorCallback) {
     socket.send({
       key, value, type: 'g', tags, callback: errorCallback,
     });
-  };
+  }
 
-  this.increment = (key, value = 1, tags, errorCallback) => {
+  function increment(key, value = 1, tags, errorCallback) {
     socket.send({
       key, value, type: 'c', tags, callback: errorCallback,
     });
-  };
+  }
 
-  this.close = () => {
+  function close() {
     socket.close();
+  }
+
+  return {
+    report,
+    increment,
+    value: _value,
+    close,
   };
 };

--- a/reporters/datadog-reporter.js
+++ b/reporters/datadog-reporter.js
@@ -1,4 +1,4 @@
-const Socket = require('../network/socket');
+const { Socket } = require('../network/socket');
 
 const redundantDotsRegex = new RegExp('\\.\\.+', 'g');
 

--- a/reporters/graphite-reporter.js
+++ b/reporters/graphite-reporter.js
@@ -4,7 +4,7 @@ module.exports = function GraphiteReporter({
   host,
   port = 8125,
   prefix,
-  tags,
+  tags: defaultTags,
   batch = true,
   maxBufferSize = 1000,
   flushInterval = 1000,
@@ -13,11 +13,11 @@ module.exports = function GraphiteReporter({
     port,
     host,
     prefix,
-    tags,
+    tags: defaultTags,
     batch,
     flushInterval,
     maxBufferSize,
-  })
+  });
 
   function report(key, value, tags, errorCallback) {
     socket.send({
@@ -27,13 +27,13 @@ module.exports = function GraphiteReporter({
 
   function _value(key, value, tags, errorCallback) {
     socket.send({
-      key, value, type: 'v', tags, callback: errorCallback
+      key, value, type: 'v', tags, callback: errorCallback,
     });
   }
 
   function increment(key, value = 1, tags, errorCallback) {
     socket.send({
-      key, value, type: 'c', tags, callback: errorCallback
+      key, value, type: 'c', tags, callback: errorCallback,
     });
   }
 

--- a/reporters/graphite-reporter.test.js
+++ b/reporters/graphite-reporter.test.js
@@ -18,7 +18,7 @@ describe('GraphiteReporter', () => {
     it('should send data to Graphite in the form of "key:value|ms"', () => new Promise(done => {
       const { send } = stubCreateSocket();
       setDate(1464260419000);
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const func = getAsyncFunc(1000);
@@ -38,10 +38,26 @@ describe('GraphiteReporter', () => {
       });
     }));
 
+    it('should not send data immediately to Graphite when batch is true', () => new Promise(done => {
+      const { send } = stubCreateSocket();
+      setDate(1464260419000);
+      const graphiteOptions = { host: '1.2.3.4', batch: true, flushInterval: 10000 };
+      const reporter = new GraphiteReporter(graphiteOptions);
+      const metrics = new Metrics([reporter]);
+      const func = getAsyncFunc(1000);
+
+      const wrappedFunc = metrics.space('space.subspace').meter(func);
+
+      wrappedFunc(1, 1, () => {
+        expect(send).not.toBeCalled();
+        done();
+      });
+    }));
+
     it('should append tags to to the metric report', () => new Promise(done => {
       const { send } = stubCreateSocket();
       setDate(1464260419000);
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const func = getAsyncFunc(1000);
@@ -65,7 +81,7 @@ describe('GraphiteReporter', () => {
     it('should append default tags to to the metric report', () => new Promise(done => {
       const { send } = stubCreateSocket();
       setDate(1464260419000);
-      const graphiteOptions = { host: '1.2.3.4', tags: { tag1: 'value1', tag2: 'value2' } };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, tags: { tag1: 'value1', tag2: 'value2' } };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const func = getAsyncFunc(1000);
@@ -89,7 +105,7 @@ describe('GraphiteReporter', () => {
     it('should merge default tags and metric level tags', () => new Promise(done => {
       const { send } = stubCreateSocket();
       setDate(1464260419000);
-      const graphiteOptions = { host: '1.2.3.4', tags: { tag1: 'value1', tag2: 'value2' } };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, tags: { tag1: 'value1', tag2: 'value2' } };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const func = getAsyncFunc(1000);
@@ -112,7 +128,7 @@ describe('GraphiteReporter', () => {
 
     it('should use the default Graphite port if no port is provided', () => new Promise(done => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const func = getAsyncFunc(1000);
@@ -131,7 +147,7 @@ describe('GraphiteReporter', () => {
 
     it('should add a valid prefix to the Graphite key when one is provided with a trailing dot', () => new Promise(done => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', prefix: 'namespace.' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, prefix: 'namespace.' };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const func = getAsyncFunc(1000);
@@ -151,7 +167,7 @@ describe('GraphiteReporter', () => {
 
     it('should add a valid prefix to the Graphite key when one is provided without a trailing dot', () => new Promise(done => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', prefix: 'namespace' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, prefix: 'namespace' };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const func = getAsyncFunc(1000);
@@ -174,7 +190,7 @@ describe('GraphiteReporter', () => {
   describe('value', () => {
     it('should send data to Graphite in the form of "key:value|v"', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
 
@@ -188,9 +204,20 @@ describe('GraphiteReporter', () => {
       expect(result.type).toEqual('v');
     });
 
+    it('should not send data immediately to Graphite when batch is true', () => {
+      const { send } = stubCreateSocket();
+      const graphiteOptions = { host: '1.2.3.4', batch: true, flushInterval: 10000 };
+      const reporter = new GraphiteReporter(graphiteOptions);
+      const metrics = new Metrics([reporter]);
+
+      metrics.space('space.subspace').value(5);
+
+      expect(send).not.toBeCalled();
+    });
+
     it('should append tags when tags are available', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
 
@@ -204,7 +231,7 @@ describe('GraphiteReporter', () => {
 
     it('should append default tags when default tags are available', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', tags: { tag1: 'value1', tag2: 'value2' } };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, tags: { tag1: 'value1', tag2: 'value2' } };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
 
@@ -218,7 +245,7 @@ describe('GraphiteReporter', () => {
 
     it('should merge default tags and metric level tags', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', tags: { tag1: 'value1', tag2: 'value2' } };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, tags: { tag1: 'value1', tag2: 'value2' } };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
 
@@ -232,7 +259,7 @@ describe('GraphiteReporter', () => {
 
     it('should use the default Graphite port if no port is provided', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const expected = 8125;
@@ -247,7 +274,7 @@ describe('GraphiteReporter', () => {
 
     it('should add a valid prefix to the Graphite key when one is provided with a trailing dot', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', prefix: 'namespace.' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, prefix: 'namespace.' };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const expected = 'namespace.space.subspace';
@@ -263,7 +290,7 @@ describe('GraphiteReporter', () => {
 
     it('should add a valid prefix to the Graphite key when one is provided without a trailing dot', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', prefix: 'namespace' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, prefix: 'namespace' };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const expected = 'namespace.space.subspace';
@@ -281,7 +308,7 @@ describe('GraphiteReporter', () => {
   describe('increment', () => {
     it('should send data to Graphite in the form of "key:value|c"', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
 
@@ -293,9 +320,20 @@ describe('GraphiteReporter', () => {
       expect(result).toEqual('space.subspace:10|c');
     });
 
+    it('should not send data immediately to Graphite when batch is true', () => {
+      const { send } = stubCreateSocket();
+      const graphiteOptions = { host: '1.2.3.4', batch: true, flushInterval: 10000 };
+      const reporter = new GraphiteReporter(graphiteOptions);
+      const metrics = new Metrics([reporter]);
+
+      metrics.space('space.subspace').increment(10);
+
+      expect(send).not.toBeCalled();
+    });
+
     it('should append tags to report when tags are available', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
 
@@ -311,6 +349,7 @@ describe('GraphiteReporter', () => {
       const { send } = stubCreateSocket();
       const graphiteOptions = {
         host: '1.2.3.4',
+        batch: false,
         tags: {
           tag1: 'value1',
           tag2: 'value2',
@@ -331,6 +370,7 @@ describe('GraphiteReporter', () => {
       const { send } = stubCreateSocket();
       const graphiteOptions = {
         host: '1.2.3.4',
+        batch: false,
         tags: {
           tag1: 'value1',
           tag2: 'value2',
@@ -349,7 +389,7 @@ describe('GraphiteReporter', () => {
 
     it('should use the default Graphite port if no port is provided', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const expected = 8125;
@@ -364,7 +404,7 @@ describe('GraphiteReporter', () => {
 
     it('should add a valid prefix to the Graphite key when one is provided with a trailing dot', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', prefix: 'namespace.' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, prefix: 'namespace.' };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const expected = 'namespace.space.subspace';
@@ -380,7 +420,7 @@ describe('GraphiteReporter', () => {
 
     it('should add a valid prefix to the Graphite key when one is provided without a trailing dot', () => {
       const { send } = stubCreateSocket();
-      const graphiteOptions = { host: '1.2.3.4', prefix: 'namespace' };
+      const graphiteOptions = { host: '1.2.3.4', batch: false, prefix: 'namespace' };
       const reporter = new GraphiteReporter(graphiteOptions);
       const metrics = new Metrics([reporter]);
       const expected = 'namespace.space.subspace';
@@ -408,6 +448,7 @@ function getAsyncFunc(duration) {
 function stubCreateSocket() {
   const socketStub = {
     send: jest.fn(),
+    unref: jest.fn(),
   };
 
   when(dgram.createSocket)

--- a/space.js
+++ b/space.js
@@ -8,7 +8,13 @@ module.exports = function Space(key, tags, reporters, errback) {
   }
 
   // eslint-disable-next-line no-console
-  const errorCallback = typeof errback === 'function' ? errback : console.log;
+  const errorCallback = typeof errback === 'function' ? errback : err => {
+    if (!err) {
+      return;
+    }
+
+    console.error(err);
+  };
 
   function forEachReporter(func) {
     reporters.forEach(reporter => {

--- a/space.js
+++ b/space.js
@@ -79,7 +79,7 @@ module.exports = function Space(key, tags, reporters, errback) {
   this.space = (nextKey, nextTags) => {
     const newKey = `${key}.${nextKey}`;
     const newTags = { ...tags, ...nextTags };
-    return new Space(newKey, newTags, reporters, errback);
+    return new Space(newKey, newTags, reporters, errorCallback);
   };
 
   function report(reportKey, start, finish) {

--- a/space.js
+++ b/space.js
@@ -7,7 +7,6 @@ module.exports = function Space(key, tags, reporters, errback) {
     throw new Error('tags must be an object');
   }
 
-  // eslint-disable-next-line no-console
   const errorCallback = typeof errback === 'function' ? errback : defaultErrorCallback;
 
   function forEachReporter(func) {

--- a/space.js
+++ b/space.js
@@ -8,13 +8,7 @@ module.exports = function Space(key, tags, reporters, errback) {
   }
 
   // eslint-disable-next-line no-console
-  const errorCallback = typeof errback === 'function' ? errback : err => {
-    if (!err) {
-      return;
-    }
-
-    console.error(err);
-  };
+  const errorCallback = typeof errback === 'function' ? errback : defaultErrorCallback;
 
   function forEachReporter(func) {
     reporters.forEach(reporter => {
@@ -104,4 +98,12 @@ function isPromise(func) {
 
 function isAsyncFunc(func) {
   return func.constructor.name === 'AsyncFunction';
+}
+
+function defaultErrorCallback(err) {
+  if (!err) {
+    return;
+  }
+
+  console.error(err);
 }


### PR DESCRIPTION
Add batch reporting to graphite reporter. 

**TL;DR:** Extract statsd logic and re-use it in both graphite and datadog, thus gaining batch reporting from the current datadog implementation

Since DD and Graphite both use statsd to report metrics, there were two options here:
1. Create a single reporter for statsd - replacing both reporters
2. Extract statsd reporting logic to a different module and reuse it in both reporters.

Option 2 was more viable at this point since there are slight differences in the actual reporting format between DataDog and Graphite. It will also give more flexibility to modify the reporters according to the specific target instead of trying to over generalize and pay the cost. Furthermore, with composition we still gain re-use of the major parts and allowing other reporters to re-use it as well without creating hard dependencies between them.

resolves #21 