### PR TITLE
Feat: Use a single error callback per reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ const errback = (err) => {    // Optional - A function to be called when an erro
 };
 
 const metrics = new Metrics({ 
-  reporters: [stringReporter, consoleReporter],
+  reporters,
   errback 
 });
 ```
@@ -191,7 +191,7 @@ const graphiteReporter = new GraphiteReporter({
   batch,
   maxBufferSize,
   flushInterval,
-errback,
+  errback,
 });
 
 const metrics = new Metrics({ reporters: [graphiteReporter] });

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "datadog",
     "DogStatsD"
   ],
-  "version": "0.11.0",
+  "version": "0.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ysa23/metrics-js"

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -1,8 +1,11 @@
+const { validate } = require('./validation/validator');
 const { Space } = require('./space');
 
 function Metrics({ reporters, errback }) {
   if (!reporters || !Array.isArray(reporters) || reporters.length === 0) throw new TypeError('reporters is missing or empty');
-  if (errback && typeof errback !== 'function') throw new TypeError('errback must be a function');
+  validate({
+    name: 'errback', value: errback, type: 'function', required: false,
+  });
 
   if (!reporters.every(r => r && typeof r.report === 'function' && typeof r.value === 'function' && typeof r.increment === 'function')) {
     throw new TypeError('must pass valid reporters with a `report` function');

--- a/src/metrics.test.js
+++ b/src/metrics.test.js
@@ -62,7 +62,7 @@ describe('Metrics', () => {
       const reporters = [new InMemoryReporter({ buffer: [] })];
 
       expect(() => new Metrics({ reporters, errback }))
-        .toThrow('errback must be a function');
+        .toThrow(TypeError);
     });
 
     it('should create a metrics object', () => {

--- a/src/network/socket.js
+++ b/src/network/socket.js
@@ -2,13 +2,16 @@ const dgram = require('dgram');
 const { validate } = require('../validation/validator');
 
 function Socket({
-  port, host, batch = true, maxBufferSize = 1000, flushInterval = 1000,
+  port, host, batch = true, maxBufferSize = 1000, flushInterval = 1000, errback,
 }) {
   validate({ name: 'port', value: port, type: 'number' });
   validate({ name: 'host', value: host, type: 'string' });
   validate({ name: 'batch', value: batch, type: 'boolean' });
   validate({ name: 'maxBufferSize', value: maxBufferSize, type: 'number' });
   validate({ name: 'flushInterval', value: flushInterval, type: 'number' });
+  validate({
+    name: 'errback', value: errback, type: 'function', required: false,
+  });
 
   const socket = dgram.createSocket('udp4');
   socket.unref();
@@ -23,18 +26,15 @@ function Socket({
     interval.unref();
   }
 
-  function send({ message, callback }) {
+  function send({ message }) {
     if (!message) {
       throw new TypeError('message is mandatory');
     }
-    if (callback && typeof callback !== 'function') {
-      throw new TypeError('callback should be a function');
-    }
 
     if (batch === true) {
-      append({ message, callback });
+      append({ message });
     } else {
-      sendImmediate({ message, callback });
+      sendImmediate({ message });
     }
   }
 
@@ -45,8 +45,8 @@ function Socket({
     }
   }
 
-  function append({ message, callback }) {
-    buffer.push({ message, callback });
+  function append({ message }) {
+    buffer.push({ message });
     bufferSize += message.length;
 
     if (bufferSize > maxBufferSize) {
@@ -60,7 +60,6 @@ function Socket({
     }
 
     const bufferedMessage = buffer.map(x => x.message).join('\n');
-    const callbacks = buffer.map(x => x.callback);
     // We capture the messages to send first to avoid concurrency issues for handling the buffer.
     // If we purge it after, new messages added to the buffer won't be sent, or worse, resent.
     bufferSize = 0;
@@ -68,25 +67,17 @@ function Socket({
 
     sendImmediate({
       message: bufferedMessage,
-      callback: err => {
-        callbacks.filter(cb => cb).forEach(cb => cb(err));
-      },
     });
   }
 
-  function sendImmediate({ message, callback }) {
+  function sendImmediate({ message }) {
     const bytes = Buffer.from(message);
     socket.send(bytes, 0, bytes.length, port, host, err => {
-      if (!callback) {
+      if (!errback || !err) {
         return;
       }
 
-      if (err) {
-        callback(err);
-        return;
-      }
-
-      callback();
+      errback(err);
     });
   }
 

--- a/src/network/socket.js
+++ b/src/network/socket.js
@@ -1,4 +1,5 @@
 const dgram = require('dgram');
+const { validate } = require('../validation/validator');
 
 function Socket({
   port, host, batch = true, maxBufferSize = 1000, flushInterval = 1000,
@@ -93,12 +94,6 @@ function Socket({
     send,
     close,
   };
-}
-
-function validate({ name, value, type }) {
-  if (value === undefined || value === null) throw new TypeError(`${name} is missing`);
-  // eslint-disable-next-line valid-typeof
-  if (typeof value !== type) throw new TypeError(`${name} is not a ${type}: ${value}: ${typeof value}`);
 }
 
 module.exports = {

--- a/src/network/statsd-socket.js
+++ b/src/network/statsd-socket.js
@@ -1,3 +1,4 @@
+const { validate } = require('../validation/validator');
 const { Socket } = require('./socket');
 
 const redundantDotsRegex = new RegExp('\\.\\.+', 'g');
@@ -26,17 +27,13 @@ function StatsdSocket({
     validate({ name: 'value', value, type: 'number' });
     validate({ name: 'type', value: type, type: 'string' });
     if (tags && (Array.isArray(tags) || typeof tags !== 'object')) throw new TypeError('tags should be an object');
-    if (callback && typeof callback !== 'function') throw new TypeError('callback should be a function');
+    validate({
+      name: 'callback', value: callback, type: 'function', required: false,
+    });
 
     const metric = `${metricPrefix}${key}:${value}|${type}${stringifyTags(tags)}`;
 
     socket.send({ message: metric, callback });
-  }
-
-  function validate({ name, value, type }) {
-    if (value === undefined || value === null || (typeof value === 'string' && value === '')) throw new TypeError(`${name} is missing`);
-    // eslint-disable-next-line valid-typeof
-    if (typeof value !== type) throw new TypeError(`${name} is not a ${type}: ${value}: ${typeof value}`);
   }
 
   function close() {

--- a/src/network/statsd-socket.js
+++ b/src/network/statsd-socket.js
@@ -11,29 +11,27 @@ function StatsdSocket({
   flushInterval = 1000,
   tags: defaultTags,
   prefix,
+  errback,
 }) {
   if (defaultTags && (Array.isArray(defaultTags) || typeof defaultTags !== 'object')) throw new TypeError('tags should be an object');
 
   const metricPrefix = typeof prefix === 'string' && prefix.length ? removeRedundantDots(`${prefix}.`) : '';
 
   const socket = new Socket({
-    host, port, batch, maxBufferSize, flushInterval,
+    host, port, batch, maxBufferSize, flushInterval, errback,
   });
 
   function send({
-    key, value, type, tags, callback,
+    key, value, type, tags,
   }) {
     validate({ name: 'key', value: key, type: 'string' });
     validate({ name: 'value', value, type: 'number' });
     validate({ name: 'type', value: type, type: 'string' });
     if (tags && (Array.isArray(tags) || typeof tags !== 'object')) throw new TypeError('tags should be an object');
-    validate({
-      name: 'callback', value: callback, type: 'function', required: false,
-    });
 
     const metric = `${metricPrefix}${key}:${value}|${type}${stringifyTags(tags)}`;
 
-    socket.send({ message: metric, callback });
+    socket.send({ message: metric });
   }
 
   function close() {

--- a/src/network/statsd-socket.test.js
+++ b/src/network/statsd-socket.test.js
@@ -38,6 +38,26 @@ describe('StatsdSocket', () => {
       });
     });
 
+    it('should create socket with given errback', () => {
+      const errback = jest.fn();
+
+      // eslint-disable-next-line no-new
+      new StatsdSocket({
+        host: '127.0.0.1',
+        port: 1234,
+        errback,
+      });
+
+      expect(Socket).toBeCalledWith({
+        host: '127.0.0.1',
+        port: 1234,
+        batch: true,
+        maxBufferSize: 1000,
+        flushInterval: 1000,
+        errback,
+      });
+    });
+
     it.each([
       ['string', 'strings'],
       ['number', 1],
@@ -149,26 +169,6 @@ describe('StatsdSocket', () => {
           tags,
         })).toThrow(TypeError);
       });
-
-      it.each([
-        ['string', 'a string'],
-        ['number', 1],
-        ['array', ['a', 'b']],
-        ['object', { key: 'value' }],
-      ])('should throw when callback is %s', (title, callback) => {
-        setSocket();
-
-        const target = new StatsdSocket({
-          host: '127.0.0.1',
-        });
-
-        expect(() => target.send({
-          key: 'space.the.final.frontier',
-          value: 1.2,
-          type: 'ms',
-          callback,
-        })).toThrow(TypeError);
-      });
     });
 
     it('should send metric', () => {
@@ -201,24 +201,6 @@ describe('StatsdSocket', () => {
       });
 
       expect(send).toBeCalledWith({ message: 'space.subspace:0|ms' });
-    });
-
-    it('should send callback when defined', () => {
-      const { send } = setSocket();
-      const callback = () => {};
-
-      const target = new StatsdSocket({
-        host: '127.0.0.1',
-      });
-
-      target.send({
-        key: 'space.subspace',
-        value: 1,
-        type: 'ms',
-        callback,
-      });
-
-      expect(send).toBeCalledWith({ message: 'space.subspace:1|ms', callback });
     });
 
     it('should append prefix if defined', () => {

--- a/src/reporters/datadog-reporter.js
+++ b/src/reporters/datadog-reporter.js
@@ -8,26 +8,27 @@ function DataDogReporter({
   batch = true,
   maxBufferSize = 1000,
   flushInterval = 1000,
+  errback,
 }) {
   const socket = new StatsdSocket({
-    port, host, batch, maxBufferSize, flushInterval, prefix, tags: defaultTags,
+    port, host, batch, maxBufferSize, flushInterval, prefix, tags: defaultTags, errback,
   });
 
-  function report(key, value, tags, errorCallback) {
+  function report(key, value, tags) {
     socket.send({
-      key, value, type: 'ms', tags, callback: errorCallback,
+      key, value, type: 'ms', tags,
     });
   }
 
-  function _value(key, value, tags, errorCallback) {
+  function _value(key, value, tags) {
     socket.send({
-      key, value, type: 'g', tags, callback: errorCallback,
+      key, value, type: 'g', tags,
     });
   }
 
-  function increment(key, value = 1, tags, errorCallback) {
+  function increment(key, value = 1, tags) {
     socket.send({
-      key, value, type: 'c', tags, callback: errorCallback,
+      key, value, type: 'c', tags,
     });
   }
 

--- a/src/reporters/graphite-reporter.js
+++ b/src/reporters/graphite-reporter.js
@@ -8,6 +8,7 @@ function GraphiteReporter({
   batch = true,
   maxBufferSize = 1000,
   flushInterval = 1000,
+  errback,
 }) {
   const socket = new StatsdSocket({
     port,
@@ -17,23 +18,24 @@ function GraphiteReporter({
     batch,
     flushInterval,
     maxBufferSize,
+    errback,
   });
 
-  function report(key, value, tags, errorCallback) {
+  function report(key, value, tags) {
     socket.send({
-      key, value, type: 'ms', tags, callback: errorCallback,
+      key, value, type: 'ms', tags,
     });
   }
 
-  function _value(key, value, tags, errorCallback) {
+  function _value(key, value, tags) {
     socket.send({
-      key, value, type: 'v', tags, callback: errorCallback,
+      key, value, type: 'v', tags,
     });
   }
 
-  function increment(key, value = 1, tags, errorCallback) {
+  function increment(key, value = 1, tags) {
     socket.send({
-      key, value, type: 'c', tags, callback: errorCallback,
+      key, value, type: 'c', tags,
     });
   }
 

--- a/src/space.js
+++ b/src/space.js
@@ -9,24 +9,24 @@ function Space({
     throw new Error('tags must be an object');
   }
 
-  const errorCallback = typeof errback === 'function' ? errback : defaultErrorCallback;
-
   function forEachReporter(func) {
     reporters.forEach(reporter => {
       try {
         func(reporter);
       } catch (e) {
-        errorCallback(e);
+        if (errback) {
+          errback(e);
+        }
       }
     });
   }
 
   this.value = val => {
-    forEachReporter(reporter => reporter.value(key, val, tags, errorCallback));
+    forEachReporter(reporter => reporter.value(key, val, tags));
   };
 
   this.increment = (val = 1) => {
-    forEachReporter(reporter => reporter.increment(key, val, tags, errorCallback));
+    forEachReporter(reporter => reporter.increment(key, val, tags));
   };
 
   this.meter = func => {
@@ -81,13 +81,13 @@ function Space({
     const newKey = `${key}.${nextKey}`;
     const newTags = { ...tags, ...nextTags };
     return new Space({
-      key: newKey, tags: newTags, reporters, errback: errorCallback,
+      key: newKey, tags: newTags, reporters, errback,
     });
   };
 
   function report(reportKey, start, finish) {
     const duration = finish.getTime() - start.getTime();
-    forEachReporter(reporter => reporter.report(reportKey, duration, tags, errorCallback));
+    forEachReporter(reporter => reporter.report(reportKey, duration, tags));
   }
 }
 
@@ -101,14 +101,6 @@ function isPromise(func) {
 
 function isAsyncFunc(func) {
   return func.constructor.name === 'AsyncFunction';
-}
-
-function defaultErrorCallback(err) {
-  if (!err) {
-    return;
-  }
-
-  console.error(err);
 }
 
 module.exports = {

--- a/src/validation/validator.js
+++ b/src/validation/validator.js
@@ -1,0 +1,19 @@
+function validate({
+  name, value, type, required = true,
+}) {
+  if (value === undefined || value === null) {
+    if (required) throw new TypeError(`${name} is missing`);
+
+    return;
+  }
+  if (typeof value === 'string' && value === '') throw new TypeError(`${name} is missing`);
+
+  // eslint-disable-next-line valid-typeof
+  if ((type === 'object' && Array.isArray(value)) || typeof value !== type) {
+    throw new TypeError(`${name} is not a ${type}: ${value}: ${typeof value}`);
+  }
+}
+
+module.exports = {
+  validate,
+};


### PR DESCRIPTION
**Motivation:**
Today each metric report is done with an error callback.
While this method works well when sending the metric immediately, when buffering is involved, its problematic:
1. More memory is required from the buffer
2. Scanning the list of callbacks when completing a send takes more time
3. From an application perspective, there's actually no sense in triggering an error per metric in batch, since it will create multiple callback triggers (generating more logs, etc...)
As the buffer size grows, these problem will increase in magnitude and will impact performance, scale and overall user experience.

**The proposed solution:**
* Each reporter will get an errback as a parameter upon creation
* The reporter will use this single callback to report errors when needed
* DataDog and Graphite implementations will change accordingly - reducing the size of the buffer and improving runtime performance
* errback will only be trigger in case of an error, and not for each send
* errback will be removed from the `Metrics` object initialization. No usage for it after this change

This is a soft **breaking change** - it will not impact functionality, but will impact current users which will need to revise the initialization of the appropriate reporters.

resolved #27 