### PR TITLE
Fix: allow an empty reporters array

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "datadog",
     "DogStatsD"
   ],
-  "version": "0.14.1",
+  "version": "0.14.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/ysa23/metrics-reporter"

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -2,7 +2,7 @@ const { validate } = require('./validation/validator');
 const { Space } = require('./space');
 
 function Metrics({ reporters, tags: defaultTags, errback }) {
-  if (!reporters || !Array.isArray(reporters) || reporters.length === 0) throw new TypeError('reporters is missing or empty');
+  if (!reporters || !Array.isArray(reporters)) throw new TypeError('reporters is missing');
   if (defaultTags && (Array.isArray(defaultTags) || typeof defaultTags !== 'object')) throw new TypeError('tags should be an object (key-value)');
 
   validate({

--- a/src/metrics.test.js
+++ b/src/metrics.test.js
@@ -44,13 +44,12 @@ describe('Metrics', () => {
     it.each([
       ['undefined', undefined],
       ['null', null],
-      ['empty array', []],
       ['number', 1],
       ['string', 'no strings on me'],
       ['object', { key: 'value' }],
     ])('should throw an error when reporters is %s', (title, reporters) => {
       expect(() => new Metrics({ reporters }))
-        .toThrow('reporters is missing or empty');
+        .toThrow('reporters is missing');
     });
 
     it.each([
@@ -63,6 +62,14 @@ describe('Metrics', () => {
 
       expect(() => new Metrics({ reporters, errback }))
         .toThrow(TypeError);
+    });
+
+    it('should not throw when reporters is an empty array', () => {
+      const reporters = [];
+      const errback = jest.fn();
+
+      expect(() => new Metrics({ reporters, errback }))
+        .not.toThrow();
     });
 
     it('should create a metrics object', () => {


### PR DESCRIPTION
In order to disable metrics reporting, the `Metrics` constructor will allow passing an empty list of reporters.