### PR TITLE
Feature: Append tags to space 

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ metrics
     .increment(); 
     // will increment 'http.requests' with 'verb:GET,path:users' tags
 ```
+Use `tags` function to create a space with the same key and additional tags:
+```js
+metrics
+    .space('http', { verb: 'GET' })
+    .tags({ path: 'users' })
+    .increment(); 
+    // will increment 'http' with 'verb:GET,path:users' tags
+```
+
 ##### Note
 When the same tag is specified when creating nested spaces, the last value will be reported
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "datadog",
     "DogStatsD"
   ],
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ysa23/metrics-reporter"

--- a/src/space.d.ts
+++ b/src/space.d.ts
@@ -17,4 +17,5 @@ export declare class Space {
   meter: <T, Args extends any[]>(func: (...args:Args) => T) => (...args: Args) => T;
 
   space: (nextKey: string, nextTags?: Tags) => Space;
+  tags: (nextTags: Tags) => Space;
 }

--- a/src/space.js
+++ b/src/space.js
@@ -85,6 +85,13 @@ function Space({
     });
   };
 
+  this.tags = nextTags => {
+    const newTags = { ...tags, ...nextTags };
+    return new Space({
+      key, tags: newTags, reporters, errback,
+    });
+  };
+
   function report(reportKey, start, finish) {
     const duration = finish.getTime() - start.getTime();
     forEachReporter(reporter => reporter.report(reportKey, duration, tags));

--- a/src/space.test.js
+++ b/src/space.test.js
@@ -388,6 +388,52 @@ describe('Space', () => {
     });
   });
 
+  describe('tags', () => {
+    it('should create a report with the same key with a combination of all tags', () => {
+      const reports = [];
+      const reporter = new InMemoryReporter({ buffer: reports });
+      const metrics = new Metrics({ reporters: [reporter] });
+      const func = getSyncFunc(500);
+      const wrappedFunc = metrics.space('space').tags({ tag1: 'value1', tag2: 'value2' }).tags({ tag3: 'value3' })
+        .meter(func);
+
+      wrappedFunc(1, 1);
+
+      expect(reports).toEqual([
+        expect.objectContaining({
+          key: 'space',
+          tags: {
+            tag1: 'value1',
+            tag2: 'value2',
+            tag3: 'value3',
+          },
+        }),
+      ]);
+    });
+
+    it('should override tag with the last value when same tag appears in different tags invocation', () => {
+      const reports = [];
+      const reporter = new InMemoryReporter({ buffer: reports });
+      const metrics = new Metrics({ reporters: [reporter] });
+      const func = getSyncFunc(500);
+      const wrappedFunc = metrics.space('space').tags({ tag1: 'value1', tag2: 'value2' }).tags({ tag3: 'value3' }).tags({ tag2: 'override-value' })
+        .meter(func);
+
+      wrappedFunc(1, 1);
+
+      expect(reports).toEqual([
+        expect.objectContaining({
+          key: 'space',
+          tags: {
+            tag1: 'value1',
+            tag2: 'override-value',
+            tag3: 'value3',
+          },
+        }),
+      ]);
+    });
+  });
+
   describe('increment', () => {
     it('when value is not specify, increment by one', () => {
       const reports = [];


### PR DESCRIPTION
New function called `tags` which creates a new space with the same key and additional tags:
```js
const space = metrics.space('some.space', { tag1: 'value1' }).tags({ tag1: 'value1' });
```