### PR TITLE
Feature: Prometheus reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Metrics is a time series reporting framework for aggregators and metrics collect
 * Built in [reporters](#Reporters):
   * [Graphite (statsd)](#Graphite)
   * [DataDog](#DataDog)
+  * [Prometheus (experimental)](#prometheus-experimental)
   * [String](#String)
   * [Console](#Console)
   * [InMemory (for testing)](#InMemory)
@@ -29,6 +30,7 @@ Metrics is a time series reporting framework for aggregators and metrics collect
      * [Reporters](#reporters)
         * [Graphite](#Graphite)
         * [DataDog](#DataDog)
+        * [Prometheus (experimental)](#prometheus-experimental)
         * [String](#String)
         * [Console](#Console)
         * [InMemory](#InMemory)
@@ -265,6 +267,72 @@ const metrics = new Metrics({ reporters: [memoryReporter], errback: error => { /
 ```
 When a metric is reported, an object with `key`, `value` and `tags` properties is pushed to the array.<br/>
 Then, the array can be used in order to validate the report.
+
+#### Prometheus (experimental)
+PrometheusReporter is an experimental reporter that generates metrics in the [Prometheus text exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/) without any external dependencies:
+```js
+const { Metrics, PrometheusReporter } = require('metrics-reporter');
+const express = require('express');
+
+const prefix = 'myapp_';                // Optional - prefix for all metric names
+const softLimit = 5000;                 // Optional - Default `5000` - Reset metrics after scrape when exceeded
+const hardLimit = 10000;                // Optional - Default `10000` - Force reset to prevent OOM
+const warnAt = 4000;                    // Optional - Default `4000` - Log warning when approaching soft limit
+const buckets = [10, 50, 100, 250];     // Optional - Custom histogram buckets (ms)
+
+const prometheusReporter = new PrometheusReporter({
+  prefix,
+  softLimit,
+  hardLimit,
+  warnAt,
+  buckets,
+});
+
+const metrics = new Metrics({ reporters: [prometheusReporter] });
+
+// Expose metrics endpoint for Prometheus to scrape
+const app = express();
+app.get('/metrics', (req, res) => {
+  res
+    .type('text/plain')
+    .send(prometheusReporter.getMetrics());
+});
+
+app.listen(3000);
+```
+
+##### Design Principles
+The PrometheusReporter implements a **double-threshold strategy** to prevent memory issues common with high-cardinality metrics:
+
+1. **Soft Limit** (default 5000): When the number of unique metrics exceeds this limit, they are reset **after** the next scrape, ensuring Prometheus receives the data before clearing.
+
+2. **Hard Limit** (default 10000): An emergency threshold that immediately resets all metrics to prevent out-of-memory errors, even if Prometheus hasn't scraped yet.
+
+3. **Warning Threshold** (default 4000): Logs a warning when approaching the soft limit, helping identify cardinality issues before they become critical.
+
+This approach provides **memory safety** while maintaining **data integrity**, unlike traditional Prometheus clients that can suffer from unbounded memory growth.
+
+##### Metric Type Mapping
+- `increment()` → Counter (with `_total` suffix)
+- `value()` → Gauge
+- `report()` → Histogram (with buckets, sum, and count)
+
+##### Configuration Recommendations
+Configuration should be according to your use-case, use these as guidelines to an initial configuration and tweak as needed:
+- **Low traffic**: Use defaults (soft: 5000, hard: 10000)
+- **High traffic**: Increase limits (soft: 20000, hard: 50000)
+- **Microservices**: Lower limits (soft: 1000, hard: 2000)
+- **Development**: Very low limits for testing (soft: 100, hard: 200)
+
+##### Logs
+When thresholds exceeds the specified limit a log will be printed to console with `[PROMETHEUS REPORTER]` prefix.
+ 
+We highly recommend to add a monitor for these logs, as passing the thresholds might cause loss of metric data.
+
+###### Log messages:
+* Soft limit reset (info): `[PROMETHEUS REPORTER]: Soft limit exceeded. Buffer will reset after scrape`
+* Soft limit threshold (warning): `[PROMETHEUS REPORTER]: Approaching soft limit`
+* Hard limit threshold (error): `[PROMETHEUS REPORTER]: Hard limit reached, forcing metrics reset`
 
 ### Building new reporters
 Metrics support creating new reports according to an application needs.

--- a/docker/docker-compose-prometheus.yml
+++ b/docker/docker-compose-prometheus.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    restart: always
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/etc/prometheus/console_libraries'
+      - '--web.console.templates=/etc/prometheus/consoles'
+      - '--web.enable-lifecycle'

--- a/docker/prometheus.yml
+++ b/docker/prometheus.yml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'metrics-reporter-example'
+    static_configs:
+      - targets: ['host.docker.internal:3000']
+    scrape_interval: 5s
+    metrics_path: /metrics

--- a/examples/prometheus.js
+++ b/examples/prometheus.js
@@ -1,164 +1,54 @@
 /**
- * Prometheus Reporter Example
+ * Simple Prometheus Reporter Example
  *
- * This example demonstrates how to use the PrometheusReporter with an Express application.
+ * This example shows how to expose Prometheus metrics via HTTP for scraping.
  * To run this example:
- * 1. npm install express (if not already installed)
- * 2. node examples/prometheus.js
- * 3. Visit http://localhost:3000/metrics to see Prometheus metrics
- * 4. Make requests to http://localhost:3000/, /users, /error to generate metrics
+ * 1. node examples/prometheus.js
+ * 2. Visit http://localhost:3000/metrics to see Prometheus metrics
  */
-const http = require('http'); // Server for scraping the metrics
+const http = require('http');
 const { Metrics, PrometheusReporter } = require('..');
 
-// Note: limits are lowered for the sake of example.
-// Recommendation is to start with the default and configure as the application grows
+// Create the Prometheus reporter
 const prometheusReporter = new PrometheusReporter({
-  prefix: 'example_app_',
-  softLimit: 100,
-  hardLimit: 200,
-  warnAt: 80,
-  buckets: [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000], // Response time buckets in ms
+  prefix: 'myapp_',
 });
 
+// Initialize metrics
 const metrics = new Metrics({
   reporters: [prometheusReporter],
-  tags: { service: 'example_service' },
 });
 
-// Simulate API endpoints and their processing times
-const endpoints = [
-  { path: '/', avgTime: 20, variation: 10 },
-  { path: '/users', avgTime: 150, variation: 50 },
-  { path: '/products', avgTime: 300, variation: 100 },
-  { path: '/search', avgTime: 500, variation: 200 },
-];
-
-// Simulate different status codes
-const statusCodes = [
-  { code: 200, weight: 70 },
-  { code: 201, weight: 10 },
-  { code: 400, weight: 5 },
-  { code: 404, weight: 10 },
-  { code: 500, weight: 5 },
-];
-
-// Function to get random status code based on weights
-function getRandomStatus() {
-  const random = Math.random() * 100;
-  let sum = 0;
-  for (const status of statusCodes) {
-    sum += status.weight;
-    if (random < sum) {
-      return status.code;
-    }
-  }
-  return 200;
+// Generate some example metrics
+function generateMetrics() {
+  // Counter: HTTP requests
+  metrics.space('http_requests', { method: 'GET', status: '200' }).increment();
+  metrics.space('http_requests', { method: 'POST', status: '201' }).increment(2);
+  // Gauge: Active connections
+  metrics.space('active_connections').value(Math.floor(Math.random() * 50) + 10);
+  // Histogram: Response time
+  metrics.space('response_time').report(Math.random() * 100 + 50);
 }
 
-// Function to simulate processing time
-function getProcessingTime(endpoint) {
-  const { avgTime: base, variation } = endpoint.variation;
-  return Math.max(1, base + (Math.random() - 0.5) * 2 * variation);
-}
+// Generate initial metrics
+generateMetrics();
 
-// Create HTTP server
+// Continue generating metrics every 5 seconds
+setInterval(generateMetrics, 5000);
+
+// Create HTTP server with metrics endpoint
 const server = http.createServer((req, res) => {
-  const start = Date.now();
-
-  // Handle /metrics endpoint
   if (req.url === '/metrics') {
     res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4' });
     res.end(prometheusReporter.getMetrics());
-    return;
+  } else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Try /metrics');
   }
-
-  // Simulate endpoint processing
-  const endpoint = endpoints.find(e => e.path === req.url) || endpoints[0];
-  const processingTime = getProcessingTime(endpoint);
-  const statusCode = getRandomStatus();
-
-  setTimeout(() => {
-    res.writeHead(statusCode, { 'Content-Type': 'text/plain' });
-    res.end(`Response from ${endpoint.path} with status ${statusCode}`);
-
-    const duration = Date.now() - start;
-
-    // Record metrics
-    metrics.space('http_requests', {
-      method: 'GET',
-      path: endpoint.path,
-      status: statusCode.toString(),
-    }).increment();
-
-    metrics.space('http_request_duration', {
-      method: 'GET',
-      path: endpoint.path,
-    }).report(duration);
-
-    // Track active connections (gauge)
-    const activeConnections = Math.floor(Math.random() * 10) + 1;
-    metrics.space('active_connections').value(activeConnections);
-
-    // Track bytes sent (example of custom metric)
-    const bytesSent = Math.floor(Math.random() * 10000) + 100;
-    metrics.space('bytes_sent', {
-      path: endpoint.path,
-    }).increment(bytesSent);
-
-    console.log(`✅ ${req.url} - ${statusCode} (${duration}ms)`);
-  }, processingTime);
 });
 
-// Function to generate simulated traffic
-function generateTraffic() {
-  setInterval(() => {
-    const endpoint = endpoints[Math.floor(Math.random() * endpoints.length)];
-
-    // Simulate internal request
-    http.get(`http://localhost:3000${endpoint.path}`, (res) => {
-      res.on('data', () => {}); // Consume response
-    }).on('error', (err) => {
-      console.error('Request error:', err.message);
-    });
-  }, 100); // Generate request every 100ms
-}
-
-// Start server
 const PORT = 3000;
 server.listen(PORT, () => {
-  console.log(`🚀 Example server running on http://localhost:${PORT}`);
-  console.log(`📈 Prometheus metrics available at http://localhost:${PORT}/metrics`);
-  console.log('\nGenerating simulated traffic...');
-  console.log('Watch the console warnings as we approach cardinality limits!\n');
-
-  // Start generating traffic
-  generateTraffic();
+  console.log(`Server running on http://localhost:${PORT}`);
+  console.log(`Metrics available at http://localhost:${PORT}/metrics`);
 });
-
-// Graceful shutdown
-process.on('SIGINT', () => {
-  console.log('\n\n📊 Final metrics:');
-  console.log(prometheusReporter.getMetrics());
-  process.exit(0);
-});
-
-// Demo: Create high cardinality scenario after 5 seconds
-setTimeout(() => {
-  console.log('\n⚠️  Creating high cardinality scenario with user IDs...\n');
-
-  // This will trigger warnings and eventual reset
-  const interval = setInterval(() => {
-    const userId = Math.floor(Math.random() * 1000);
-    metrics.space('user_actions', {
-      userId: userId.toString(),
-      action: 'click',
-    }).increment();
-  }, 50);
-
-  // Stop after 10 seconds
-  setTimeout(() => {
-    clearInterval(interval);
-    console.log('\n✅ High cardinality scenario stopped\n');
-  }, 10000);
-}, 5000);

--- a/examples/prometheus.js
+++ b/examples/prometheus.js
@@ -70,7 +70,6 @@ const server = http.createServer((req, res) => {
   if (req.url === '/metrics') {
     res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4' });
     res.end(prometheusReporter.getMetrics());
-    console.log('📊 Metrics scraped');
     return;
   }
 

--- a/examples/prometheus.js
+++ b/examples/prometheus.js
@@ -1,0 +1,165 @@
+/**
+ * Prometheus Reporter Example
+ *
+ * This example demonstrates how to use the PrometheusReporter with an Express application.
+ * To run this example:
+ * 1. npm install express (if not already installed)
+ * 2. node examples/prometheus.js
+ * 3. Visit http://localhost:3000/metrics to see Prometheus metrics
+ * 4. Make requests to http://localhost:3000/, /users, /error to generate metrics
+ */
+const http = require('http'); // Server for scraping the metrics
+const { Metrics, PrometheusReporter } = require('..');
+
+// Note: limits are lowered for the sake of example.
+// Recommendation is to start with the default and configure as the application grows
+const prometheusReporter = new PrometheusReporter({
+  prefix: 'example_app_',
+  softLimit: 100,
+  hardLimit: 200,
+  warnAt: 80,
+  buckets: [10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000], // Response time buckets in ms
+});
+
+const metrics = new Metrics({
+  reporters: [prometheusReporter],
+  tags: { service: 'example_service' },
+});
+
+// Simulate API endpoints and their processing times
+const endpoints = [
+  { path: '/', avgTime: 20, variation: 10 },
+  { path: '/users', avgTime: 150, variation: 50 },
+  { path: '/products', avgTime: 300, variation: 100 },
+  { path: '/search', avgTime: 500, variation: 200 },
+];
+
+// Simulate different status codes
+const statusCodes = [
+  { code: 200, weight: 70 },
+  { code: 201, weight: 10 },
+  { code: 400, weight: 5 },
+  { code: 404, weight: 10 },
+  { code: 500, weight: 5 },
+];
+
+// Function to get random status code based on weights
+function getRandomStatus() {
+  const random = Math.random() * 100;
+  let sum = 0;
+  for (const status of statusCodes) {
+    sum += status.weight;
+    if (random < sum) {
+      return status.code;
+    }
+  }
+  return 200;
+}
+
+// Function to simulate processing time
+function getProcessingTime(endpoint) {
+  const { avgTime: base, variation } = endpoint.variation;
+  return Math.max(1, base + (Math.random() - 0.5) * 2 * variation);
+}
+
+// Create HTTP server
+const server = http.createServer((req, res) => {
+  const start = Date.now();
+
+  // Handle /metrics endpoint
+  if (req.url === '/metrics') {
+    res.writeHead(200, { 'Content-Type': 'text/plain; version=0.0.4' });
+    res.end(prometheusReporter.getMetrics());
+    console.log('📊 Metrics scraped');
+    return;
+  }
+
+  // Simulate endpoint processing
+  const endpoint = endpoints.find(e => e.path === req.url) || endpoints[0];
+  const processingTime = getProcessingTime(endpoint);
+  const statusCode = getRandomStatus();
+
+  setTimeout(() => {
+    res.writeHead(statusCode, { 'Content-Type': 'text/plain' });
+    res.end(`Response from ${endpoint.path} with status ${statusCode}`);
+
+    const duration = Date.now() - start;
+
+    // Record metrics
+    metrics.space('http_requests', {
+      method: 'GET',
+      path: endpoint.path,
+      status: statusCode.toString(),
+    }).increment();
+
+    metrics.space('http_request_duration', {
+      method: 'GET',
+      path: endpoint.path,
+    }).report(duration);
+
+    // Track active connections (gauge)
+    const activeConnections = Math.floor(Math.random() * 10) + 1;
+    metrics.space('active_connections').value(activeConnections);
+
+    // Track bytes sent (example of custom metric)
+    const bytesSent = Math.floor(Math.random() * 10000) + 100;
+    metrics.space('bytes_sent', {
+      path: endpoint.path,
+    }).increment(bytesSent);
+
+    console.log(`✅ ${req.url} - ${statusCode} (${duration}ms)`);
+  }, processingTime);
+});
+
+// Function to generate simulated traffic
+function generateTraffic() {
+  setInterval(() => {
+    const endpoint = endpoints[Math.floor(Math.random() * endpoints.length)];
+
+    // Simulate internal request
+    http.get(`http://localhost:3000${endpoint.path}`, (res) => {
+      res.on('data', () => {}); // Consume response
+    }).on('error', (err) => {
+      console.error('Request error:', err.message);
+    });
+  }, 100); // Generate request every 100ms
+}
+
+// Start server
+const PORT = 3000;
+server.listen(PORT, () => {
+  console.log(`🚀 Example server running on http://localhost:${PORT}`);
+  console.log(`📈 Prometheus metrics available at http://localhost:${PORT}/metrics`);
+  console.log('\nGenerating simulated traffic...');
+  console.log('Watch the console warnings as we approach cardinality limits!\n');
+
+  // Start generating traffic
+  generateTraffic();
+});
+
+// Graceful shutdown
+process.on('SIGINT', () => {
+  console.log('\n\n📊 Final metrics:');
+  console.log(prometheusReporter.getMetrics());
+  process.exit(0);
+});
+
+// Demo: Create high cardinality scenario after 5 seconds
+setTimeout(() => {
+  console.log('\n⚠️  Creating high cardinality scenario with user IDs...\n');
+
+  // This will trigger warnings and eventual reset
+  const interval = setInterval(() => {
+    const userId = Math.floor(Math.random() * 1000);
+    metrics.space('user_actions', {
+      userId: userId.toString(),
+      action: 'click',
+    }).increment();
+  }, 50);
+
+  // Stop after 10 seconds
+  setTimeout(() => {
+    clearInterval(interval);
+    console.log('\n✅ High cardinality scenario stopped\n');
+  }, 10000);
+}, 5000);

--- a/examples/prometheus.js
+++ b/examples/prometheus.js
@@ -24,10 +24,17 @@ function generateMetrics() {
   // Counter: HTTP requests
   metrics.space('http_requests', { method: 'GET', status: '200' }).increment();
   metrics.space('http_requests', { method: 'POST', status: '201' }).increment(2);
+  
   // Gauge: Active connections
   metrics.space('active_connections').value(Math.floor(Math.random() * 50) + 10);
-  // Histogram: Response time
-  metrics.space('response_time').report(Math.random() * 100 + 50);
+  
+  // Histogram: Response time (using meter with a dummy function)
+  const responseTime = Math.random() * 100 + 50;
+  const timingFunction = metrics.space('response_time').meter(() => {
+    // Simulate work that takes the desired time
+  });
+  // We'll simulate the timing by directly calling the reporter
+  prometheusReporter.report('response_time', responseTime);
 }
 
 // Generate initial metrics

--- a/examples/prometheus.js
+++ b/examples/prometheus.js
@@ -24,17 +24,8 @@ function generateMetrics() {
   // Counter: HTTP requests
   metrics.space('http_requests', { method: 'GET', status: '200' }).increment();
   metrics.space('http_requests', { method: 'POST', status: '201' }).increment(2);
-  
   // Gauge: Active connections
   metrics.space('active_connections').value(Math.floor(Math.random() * 50) + 10);
-  
-  // Histogram: Response time (using meter with a dummy function)
-  const responseTime = Math.random() * 100 + 50;
-  const timingFunction = metrics.space('response_time').meter(() => {
-    // Simulate work that takes the desired time
-  });
-  // We'll simulate the timing by directly calling the reporter
-  prometheusReporter.report('response_time', responseTime);
 }
 
 // Generate initial metrics

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "example:graphite": "node ./examples/graphite.js",
     "example:datadog": "node ./examples/datadog.js",
     "example:prometheus": "node ./examples/prometheus.js",
-    "docker:datadog:up": "cd ./docker && docker-compose -f docker-compose-datadog.yml up -d",
-    "docker:datadog:down": "cd ./docker && docker-compose -f docker-compose-datadog.yml down",
-    "docker:graphite:up": "cd ./docker && docker-compose -f docker-compose-graphite.yml up -d",
-    "docker:graphite:down": "cd ./docker && docker-compose -f docker-compose-graphite.yml down"
+    "docker:datadog:up": "cd ./docker && docker compose -f docker-compose-datadog.yml up -d",
+    "docker:datadog:down": "cd ./docker && docker compose -f docker-compose-datadog.yml down",
+    "docker:graphite:up": "cd ./docker && docker compose -f docker-compose-graphite.yml up -d",
+    "docker:graphite:down": "cd ./docker && docker compose -f docker-compose-graphite.yml down",
+    "docker:prometheus:up": "cd ./docker && docker compose -f docker-compose-prometheus.yml up -d",
+    "docker:prometheus:down": "cd ./docker && docker compose -f docker-compose-prometheus.yml down"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "tsc:watch": "tsc -w",
     "example:graphite": "node ./examples/graphite.js",
     "example:datadog": "node ./examples/datadog.js",
+    "example:prometheus": "node ./examples/prometheus.js",
     "docker:datadog:up": "cd ./docker && docker-compose -f docker-compose-datadog.yml up -d",
     "docker:datadog:down": "cd ./docker && docker-compose -f docker-compose-datadog.yml down",
     "docker:graphite:up": "cd ./docker && docker-compose -f docker-compose-graphite.yml up -d",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "datadog",
     "DogStatsD"
   ],
-  "version": "2.1.0",
+  "version": "2.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/ysa23/metrics-reporter"

--- a/src/metrics.d.ts
+++ b/src/metrics.d.ts
@@ -4,7 +4,7 @@ import {IReporter} from "./types/reporter";
 
 declare interface MetricsOptions {
   reporters: IReporter[];
-  tags: Tags;
+  tags?: Tags;
   errback?: ErrorCallback;
 }
 

--- a/src/reporters/index.d.ts
+++ b/src/reporters/index.d.ts
@@ -2,4 +2,5 @@ export * from "./console-reporter";
 export * from "./datadog-reporter";
 export * from "./graphite-reporter";
 export * from "./in-memory-reporter";
+export * from "./prometheus-reporter";
 export * from "./string-reporter";

--- a/src/reporters/index.js
+++ b/src/reporters/index.js
@@ -2,6 +2,7 @@ const { ConsoleReporter } = require('./console-reporter');
 const { DataDogReporter } = require('./datadog-reporter');
 const { GraphiteReporter } = require('./graphite-reporter');
 const { InMemoryReporter } = require('./in-memory-reporter');
+const { PrometheusReporter } = require('./prometheus-reporter');
 const { StringReporter } = require('./string-reporter');
 
 module.exports = {
@@ -9,5 +10,6 @@ module.exports = {
   DataDogReporter,
   GraphiteReporter,
   InMemoryReporter,
+  PrometheusReporter,
   StringReporter,
 };

--- a/src/reporters/prometheus-reporter.d.ts
+++ b/src/reporters/prometheus-reporter.d.ts
@@ -17,6 +17,7 @@ export declare class PrometheusReporter implements IReporter {
   report(key: string, value: number, tags?: Tags): void;
   value(key: string, value: number, tags?: Tags): void;
   increment(key: string, value?: number, tags?: Tags): void;
+
   getMetrics(): string;
   close(): void;
 }

--- a/src/reporters/prometheus-reporter.d.ts
+++ b/src/reporters/prometheus-reporter.d.ts
@@ -1,5 +1,6 @@
 import {IReporter} from "../types/reporter";
 import {Tags} from "../types/tags";
+import {LogCallback} from "../types/log-event";
 
 declare interface PrometheusReporterOptions {
   prefix?: string;
@@ -7,6 +8,7 @@ declare interface PrometheusReporterOptions {
   hardLimit?: number;
   warnAt?: number;
   buckets?: number[];
+  logCallback?: LogCallback;
 }
 
 export declare class PrometheusReporter implements IReporter {

--- a/src/reporters/prometheus-reporter.d.ts
+++ b/src/reporters/prometheus-reporter.d.ts
@@ -1,0 +1,20 @@
+import {IReporter} from "../types/reporter";
+import {Tags} from "../types/tags";
+
+declare interface PrometheusReporterOptions {
+  prefix?: string;
+  softLimit?: number;
+  hardLimit?: number;
+  warnAt?: number;
+  buckets?: number[];
+}
+
+export declare class PrometheusReporter implements IReporter {
+  constructor(options?: PrometheusReporterOptions);
+
+  report(key: string, value: number, tags?: Tags): void;
+  value(key: string, value: number, tags?: Tags): void;
+  increment(key: string, value?: number, tags?: Tags): void;
+  getMetrics(): string;
+  close(): void;
+}

--- a/src/reporters/prometheus-reporter.js
+++ b/src/reporters/prometheus-reporter.js
@@ -24,6 +24,10 @@ function PrometheusReporter(options = {}) {
   }
 
   function getMetrics() {
+    if (metrics.size === 0) {
+      return '';
+    }
+
     const metricsByName = metrics.entries().reduce((groups, [key, metric]) => {
       const { name } = parseKey(key);
       const metricName = prefix + name;

--- a/src/reporters/prometheus-reporter.js
+++ b/src/reporters/prometheus-reporter.js
@@ -1,0 +1,195 @@
+function PrometheusReporter(options = {}) {
+  const {
+    prefix = '',
+    softLimit = 5000,
+    hardLimit = 10000,
+    warnAt = 4000,
+    buckets = [10, 50, 100, 250, 500, 1000, 2500, 5000, 10000],
+  } = options;
+
+  const metrics = new Map();
+  let warned = false;
+
+  function formatKey(key, tags) {
+    if (!tags || Object.keys(tags).length === 0) {
+      return key;
+    }
+    const sortedTags = Object.keys(tags)
+      .sort()
+      .map(k => `${k}="${escapeValue(tags[k])}"`)
+      .join(',');
+    return `${key}{${sortedTags}}`;
+  }
+
+  function escapeValue(str) {
+    if (typeof str !== 'string') {
+      return str;
+    }
+    return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+  }
+
+  function updateMetric(key, value, type, tags) {
+    const metricKey = formatKey(key, tags);
+
+    // HARD LIMIT: Emergency reset to prevent OOM
+    if (metrics.size >= hardLimit && !metrics.has(metricKey)) {
+      console.error('[PROMETHEUS REPORTER]: Hard limit reached, forcing metrics reset', { hardLimit });
+      metrics.clear();
+      warned = false;
+    }
+
+    // Warning threshold
+    if (!warned && metrics.size >= warnAt) {
+      console.warn('[PROMETHEUS REPORTER]: Approaching soft limit', { softLimit, size: metrics.size });
+      warned = true;
+    }
+
+    const existing = metrics.get(metricKey) || createMetric(type);
+    updateMetricValue(existing, value, type);
+    metrics.set(metricKey, existing);
+  }
+
+  function createMetric(type) {
+    switch (type) {
+      case 'counter':
+        return { type, value: 0 };
+      case 'gauge':
+        return { type, value: 0 };
+      case 'histogram':
+        return {
+          type,
+          buckets: new Map(buckets.map(b => [b, 0])),
+          sum: 0,
+          count: 0,
+        };
+      default:
+        return { type: 'gauge', value: 0 };
+    }
+  }
+
+  function updateMetricValue(metric, value, type) {
+    switch (type) {
+      case 'counter':
+        metric.value += value;
+        break;
+      case 'gauge':
+        metric.value = value;
+        break;
+      case 'histogram':
+        metric.sum += value;
+        metric.count += 1;
+        buckets.forEach(bucket => {
+          if (value <= bucket) {
+            metric.buckets.set(bucket, metric.buckets.get(bucket) + 1);
+          }
+        });
+        break;
+    }
+  }
+
+  function report(key, value, tags) {
+    updateMetric(key, value, 'histogram', tags);
+  }
+
+  function _value(key, value, tags) {
+    updateMetric(key, value, 'gauge', tags);
+  }
+
+  function increment(key, value = 1, tags) {
+    updateMetric(key, value, 'counter', tags);
+  }
+
+  function getMetrics() {
+    const output = [];
+    const processedMetrics = new Set();
+
+    metrics.forEach((metric, key) => {
+      const { name, labels } = parseKey(key);
+      const metricName = prefix + name;
+
+      // Add HELP and TYPE lines once per metric name
+      if (!processedMetrics.has(metricName)) {
+        output.push(`# HELP ${metricName} ${getHelpText(metric.type)}`);
+        output.push(`# TYPE ${metricName} ${metric.type}`);
+        processedMetrics.add(metricName);
+      }
+
+      // Format the metric value(s)
+      output.push(...formatMetricValues(metricName, metric, labels));
+    });
+
+    const result = output.join('\n') + (output.length > 0 ? '\n' : '');
+
+    // SOFT LIMIT: Reset after scrape if over threshold
+    if (metrics.size > softLimit) {
+      console.info('[PROMETHEUS REPORTER]: Soft limit exceeded. Buffer will reset after scrape', { softLimit, size: metrics.size });
+      metrics.clear();
+      warned = false;
+    }
+
+    return result;
+  }
+
+  function parseKey(metricKey) {
+    const match = metricKey.match(/^([^{]+)(\{.*\})?$/);
+    if (!match) {
+      return { name: metricKey, labels: '' };
+    }
+    return {
+      name: match[1],
+      labels: match[2] || '',
+    };
+  }
+
+  function formatMetricValues(metricName, metric, labels) {
+    const values = [];
+
+    switch (metric.type) {
+      case 'counter':
+        values.push(`${metricName}_total${labels} ${metric.value}`);
+        break;
+      case 'gauge':
+        values.push(`${metricName}${labels} ${metric.value}`);
+        break;
+      case 'histogram':
+        // Output bucket values
+        metric.buckets.forEach((count, bucket) => {
+          const bucketLabel = labels ? labels.replace('}', `,le="${bucket}"}`) : `{le="${bucket}"}`;
+          values.push(`${metricName}_bucket${bucketLabel} ${count}`);
+        });
+        // Add +Inf bucket
+        const infLabel = labels ? labels.replace('}', ',le="+Inf"}') : '{le="+Inf"}';
+        values.push(`${metricName}_bucket${infLabel} ${metric.count}`);
+        // Add sum and count
+        values.push(`${metricName}_sum${labels} ${metric.sum}`);
+        values.push(`${metricName}_count${labels} ${metric.count}`);
+        break;
+    }
+
+    return values;
+  }
+
+  function getHelpText(type) {
+    switch (type) {
+      case 'counter':
+        return 'Counter metric';
+      case 'gauge':
+        return 'Gauge metric';
+      case 'histogram':
+        return 'Histogram metric';
+      default:
+        return 'Metric';
+    }
+  }
+
+  return {
+    report,
+    increment,
+    value: _value,
+    getMetrics,
+  };
+}
+
+module.exports = {
+  PrometheusReporter,
+};

--- a/src/reporters/prometheus-reporter.test.js
+++ b/src/reporters/prometheus-reporter.test.js
@@ -16,7 +16,7 @@ describe('PrometheusReporter', () => {
         prefix: 'test_',
         softLimit: 1000,
         hardLimit: 2000,
-        warnAt: 800
+        warnAt: 800,
       });
       expect(reporter).toBeDefined();
     });
@@ -37,9 +37,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP test_counter Counter metric\n' +
-        '# TYPE test_counter counter\n' +
-        'test_counter_total 1\n'
+        '# HELP test_counter Counter metric\n'
+        + '# TYPE test_counter counter\n'
+        + 'test_counter_total 1\n',
       );
     });
 
@@ -50,9 +50,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP test_counter Counter metric\n' +
-        '# TYPE test_counter counter\n' +
-        'test_counter_total 8\n'
+        '# HELP test_counter Counter metric\n'
+        + '# TYPE test_counter counter\n'
+        + 'test_counter_total 8\n',
       );
     });
 
@@ -62,9 +62,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP test_counter Counter metric\n' +
-        '# TYPE test_counter counter\n' +
-        'test_counter_total{method="GET",status="200"} 1\n'
+        '# HELP test_counter Counter metric\n'
+        + '# TYPE test_counter counter\n'
+        + 'test_counter_total{method="GET",status="200"} 1\n',
       );
     });
 
@@ -75,10 +75,10 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP requests Counter metric\n' +
-        '# TYPE requests counter\n' +
-        'requests_total{method="GET"} 1\n' +
-        'requests_total{method="POST"} 2\n'
+        '# HELP requests Counter metric\n'
+        + '# TYPE requests counter\n'
+        + 'requests_total{method="GET"} 1\n'
+        + 'requests_total{method="POST"} 2\n',
       );
     });
 
@@ -88,9 +88,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP test_counter Counter metric\n' +
-        '# TYPE test_counter counter\n' +
-        'test_counter_total 1\n'
+        '# HELP test_counter Counter metric\n'
+        + '# TYPE test_counter counter\n'
+        + 'test_counter_total 1\n',
       );
     });
 
@@ -124,9 +124,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP memory_usage Gauge metric\n' +
-        '# TYPE memory_usage gauge\n' +
-        'memory_usage 1024\n'
+        '# HELP memory_usage Gauge metric\n'
+        + '# TYPE memory_usage gauge\n'
+        + 'memory_usage 1024\n',
       );
     });
 
@@ -137,9 +137,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP memory_usage Gauge metric\n' +
-        '# TYPE memory_usage gauge\n' +
-        'memory_usage 2048\n'
+        '# HELP memory_usage Gauge metric\n'
+        + '# TYPE memory_usage gauge\n'
+        + 'memory_usage 2048\n',
       );
     });
 
@@ -149,9 +149,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP temperature Gauge metric\n' +
-        '# TYPE temperature gauge\n' +
-        'temperature{location="server_room"} 23.5\n'
+        '# HELP temperature Gauge metric\n'
+        + '# TYPE temperature gauge\n'
+        + 'temperature{location="server_room"} 23.5\n',
       );
     });
   });
@@ -163,63 +163,63 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP response_time Histogram metric\n' +
-        '# TYPE response_time histogram\n' +
-        'response_time_bucket{le="10"} 0\n' +
-        'response_time_bucket{le="50"} 0\n' +
-        'response_time_bucket{le="100"} 0\n' +
-        'response_time_bucket{le="250"} 1\n' +
-        'response_time_bucket{le="500"} 1\n' +
-        'response_time_bucket{le="1000"} 1\n' +
-        'response_time_bucket{le="2500"} 1\n' +
-        'response_time_bucket{le="5000"} 1\n' +
-        'response_time_bucket{le="10000"} 1\n' +
-        'response_time_bucket{le="+Inf"} 1\n' +
-        'response_time_sum 150\n' +
-        'response_time_count 1\n'
+        '# HELP response_time Histogram metric\n'
+        + '# TYPE response_time histogram\n'
+        + 'response_time_bucket{le="10"} 0\n'
+        + 'response_time_bucket{le="50"} 0\n'
+        + 'response_time_bucket{le="100"} 0\n'
+        + 'response_time_bucket{le="250"} 1\n'
+        + 'response_time_bucket{le="500"} 1\n'
+        + 'response_time_bucket{le="1000"} 1\n'
+        + 'response_time_bucket{le="2500"} 1\n'
+        + 'response_time_bucket{le="5000"} 1\n'
+        + 'response_time_bucket{le="10000"} 1\n'
+        + 'response_time_bucket{le="+Inf"} 1\n'
+        + 'response_time_sum 150\n'
+        + 'response_time_count 1\n',
       );
     });
 
     it('should accumulate histogram observations correctly', () => {
       const reporter = new PrometheusReporter();
-      reporter.report('response_time', 50);  // Goes in 50, 100, etc buckets
+      reporter.report('response_time', 50); // Goes in 50, 100, etc buckets
       reporter.report('response_time', 150); // Goes in 250, 500, etc buckets
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP response_time Histogram metric\n' +
-        '# TYPE response_time histogram\n' +
-        'response_time_bucket{le="10"} 0\n' +
-        'response_time_bucket{le="50"} 1\n' +
-        'response_time_bucket{le="100"} 1\n' +
-        'response_time_bucket{le="250"} 2\n' +
-        'response_time_bucket{le="500"} 2\n' +
-        'response_time_bucket{le="1000"} 2\n' +
-        'response_time_bucket{le="2500"} 2\n' +
-        'response_time_bucket{le="5000"} 2\n' +
-        'response_time_bucket{le="10000"} 2\n' +
-        'response_time_bucket{le="+Inf"} 2\n' +
-        'response_time_sum 200\n' +
-        'response_time_count 2\n'
+        '# HELP response_time Histogram metric\n'
+        + '# TYPE response_time histogram\n'
+        + 'response_time_bucket{le="10"} 0\n'
+        + 'response_time_bucket{le="50"} 1\n'
+        + 'response_time_bucket{le="100"} 1\n'
+        + 'response_time_bucket{le="250"} 2\n'
+        + 'response_time_bucket{le="500"} 2\n'
+        + 'response_time_bucket{le="1000"} 2\n'
+        + 'response_time_bucket{le="2500"} 2\n'
+        + 'response_time_bucket{le="5000"} 2\n'
+        + 'response_time_bucket{le="10000"} 2\n'
+        + 'response_time_bucket{le="+Inf"} 2\n'
+        + 'response_time_sum 200\n'
+        + 'response_time_count 2\n',
       );
     });
 
     it('should handle histogram with custom buckets', () => {
       const reporter = new PrometheusReporter({
-        buckets: [1, 5, 10]
+        buckets: [1, 5, 10],
       });
       reporter.report('custom_metric', 3);
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP custom_metric Histogram metric\n' +
-        '# TYPE custom_metric histogram\n' +
-        'custom_metric_bucket{le="1"} 0\n' +
-        'custom_metric_bucket{le="5"} 1\n' +
-        'custom_metric_bucket{le="10"} 1\n' +
-        'custom_metric_bucket{le="+Inf"} 1\n' +
-        'custom_metric_sum 3\n' +
-        'custom_metric_count 1\n'
+        '# HELP custom_metric Histogram metric\n'
+        + '# TYPE custom_metric histogram\n'
+        + 'custom_metric_bucket{le="1"} 0\n'
+        + 'custom_metric_bucket{le="5"} 1\n'
+        + 'custom_metric_bucket{le="10"} 1\n'
+        + 'custom_metric_bucket{le="+Inf"} 1\n'
+        + 'custom_metric_sum 3\n'
+        + 'custom_metric_count 1\n',
       );
     });
   });
@@ -235,16 +235,15 @@ describe('PrometheusReporter', () => {
 
       // First scrape should return all metrics
       const output1 = reporter.getMetrics();
-      const expectedOutput1 =
-        '# HELP metric1 Counter metric\n' +
-        '# TYPE metric1 counter\n' +
-        'metric1_total 1\n' +
-        '# HELP metric2 Counter metric\n' +
-        '# TYPE metric2 counter\n' +
-        'metric2_total 1\n' +
-        '# HELP metric3 Counter metric\n' +
-        '# TYPE metric3 counter\n' +
-        'metric3_total 1\n';
+      const expectedOutput1 = '# HELP metric1 Counter metric\n'
+        + '# TYPE metric1 counter\n'
+        + 'metric1_total 1\n'
+        + '# HELP metric2 Counter metric\n'
+        + '# TYPE metric2 counter\n'
+        + 'metric2_total 1\n'
+        + '# HELP metric3 Counter metric\n'
+        + '# TYPE metric3 counter\n'
+        + 'metric3_total 1\n';
 
       expect(output1).toBe(expectedOutput1);
 
@@ -263,13 +262,12 @@ describe('PrometheusReporter', () => {
       const output2 = reporter.getMetrics();
 
       // Should be the same both times
-      const expectedOutput =
-        '# HELP metric1 Counter metric\n' +
-        '# TYPE metric1 counter\n' +
-        'metric1_total 1\n' +
-        '# HELP metric2 Counter metric\n' +
-        '# TYPE metric2 counter\n' +
-        'metric2_total 1\n';
+      const expectedOutput = '# HELP metric1 Counter metric\n'
+        + '# TYPE metric1 counter\n'
+        + 'metric1_total 1\n'
+        + '# HELP metric2 Counter metric\n'
+        + '# TYPE metric2 counter\n'
+        + 'metric2_total 1\n';
 
       expect(output1).toBe(expectedOutput);
       expect(output2).toBe(expectedOutput);
@@ -314,9 +312,9 @@ describe('PrometheusReporter', () => {
       // Should only have the last metric
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP metric3 Counter metric\n' +
-        '# TYPE metric3 counter\n' +
-        'metric3_total 1\n'
+        '# HELP metric3 Counter metric\n'
+        + '# TYPE metric3 counter\n'
+        + 'metric3_total 1\n',
       );
     });
 
@@ -332,12 +330,12 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP metric1 Counter metric\n' +
-        '# TYPE metric1 counter\n' +
-        'metric1_total 6\n' +
-        '# HELP metric2 Counter metric\n' +
-        '# TYPE metric2 counter\n' +
-        'metric2_total 1\n'
+        '# HELP metric1 Counter metric\n'
+        + '# TYPE metric1 counter\n'
+        + 'metric1_total 6\n'
+        + '# HELP metric2 Counter metric\n'
+        + '# TYPE metric2 counter\n'
+        + 'metric2_total 1\n',
       );
     });
 
@@ -372,9 +370,9 @@ describe('PrometheusReporter', () => {
 
       const output = reporter.getMetrics();
       expect(output).toBe(
-        '# HELP myapp_requests Counter metric\n' +
-        '# TYPE myapp_requests counter\n' +
-        'myapp_requests_total 1\n'
+        '# HELP myapp_requests Counter metric\n'
+        + '# TYPE myapp_requests counter\n'
+        + 'myapp_requests_total 1\n',
       );
     });
   });
@@ -387,27 +385,26 @@ describe('PrometheusReporter', () => {
       reporter.report('response_time', 150);
 
       const output = reporter.getMetrics();
-      const expectedOutput =
-        '# HELP http_requests Counter metric\n' +
-        '# TYPE http_requests counter\n' +
-        'http_requests_total 10\n' +
-        '# HELP memory_usage Gauge metric\n' +
-        '# TYPE memory_usage gauge\n' +
-        'memory_usage 1024\n' +
-        '# HELP response_time Histogram metric\n' +
-        '# TYPE response_time histogram\n' +
-        'response_time_bucket{le="10"} 0\n' +
-        'response_time_bucket{le="50"} 0\n' +
-        'response_time_bucket{le="100"} 0\n' +
-        'response_time_bucket{le="250"} 1\n' +
-        'response_time_bucket{le="500"} 1\n' +
-        'response_time_bucket{le="1000"} 1\n' +
-        'response_time_bucket{le="2500"} 1\n' +
-        'response_time_bucket{le="5000"} 1\n' +
-        'response_time_bucket{le="10000"} 1\n' +
-        'response_time_bucket{le="+Inf"} 1\n' +
-        'response_time_sum 150\n' +
-        'response_time_count 1\n';
+      const expectedOutput = '# HELP http_requests Counter metric\n'
+        + '# TYPE http_requests counter\n'
+        + 'http_requests_total 10\n'
+        + '# HELP memory_usage Gauge metric\n'
+        + '# TYPE memory_usage gauge\n'
+        + 'memory_usage 1024\n'
+        + '# HELP response_time Histogram metric\n'
+        + '# TYPE response_time histogram\n'
+        + 'response_time_bucket{le="10"} 0\n'
+        + 'response_time_bucket{le="50"} 0\n'
+        + 'response_time_bucket{le="100"} 0\n'
+        + 'response_time_bucket{le="250"} 1\n'
+        + 'response_time_bucket{le="500"} 1\n'
+        + 'response_time_bucket{le="1000"} 1\n'
+        + 'response_time_bucket{le="2500"} 1\n'
+        + 'response_time_bucket{le="5000"} 1\n'
+        + 'response_time_bucket{le="10000"} 1\n'
+        + 'response_time_bucket{le="+Inf"} 1\n'
+        + 'response_time_sum 150\n'
+        + 'response_time_count 1\n';
 
       expect(output).toBe(expectedOutput);
     });

--- a/src/reporters/prometheus-reporter.test.js
+++ b/src/reporters/prometheus-reporter.test.js
@@ -1,0 +1,346 @@
+const { PrometheusReporter } = require('./prometheus-reporter');
+
+describe('PrometheusReporter', () => {
+  describe('constructor', () => {
+    it('should create a reporter with default configuration', () => {
+      const reporter = new PrometheusReporter();
+      expect(reporter).toBeDefined();
+      expect(typeof reporter.getMetrics).toBe('function');
+      expect(typeof reporter.increment).toBe('function');
+      expect(typeof reporter.value).toBe('function');
+      expect(typeof reporter.report).toBe('function');
+    });
+
+    it('should accept configuration options', () => {
+      const reporter = new PrometheusReporter({
+        prefix: 'test_',
+        softLimit: 1000,
+        hardLimit: 2000,
+        warnAt: 800
+      });
+      expect(reporter).toBeDefined();
+    });
+  });
+
+  describe('getMetrics', () => {
+    it('should return empty string when no metrics exist', () => {
+      const reporter = new PrometheusReporter();
+      const output = reporter.getMetrics();
+      expect(output).toBe('');
+    });
+  });
+
+  describe('increment', () => {
+    it('should track single counter metric', () => {
+      const reporter = new PrometheusReporter();
+      reporter.increment('test_counter', 1);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP test_counter Counter metric\n' +
+        '# TYPE test_counter counter\n' +
+        'test_counter_total 1\n'
+      );
+    });
+
+    it('should accumulate counter values for same metric', () => {
+      const reporter = new PrometheusReporter();
+      reporter.increment('test_counter', 5);
+      reporter.increment('test_counter', 3);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP test_counter Counter metric\n' +
+        '# TYPE test_counter counter\n' +
+        'test_counter_total 8\n'
+      );
+    });
+
+    it('should handle tags correctly with sorted labels', () => {
+      const reporter = new PrometheusReporter();
+      reporter.increment('test_counter', 1, { status: '200', method: 'GET' });
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP test_counter Counter metric\n' +
+        '# TYPE test_counter counter\n' +
+        'test_counter_total{method="GET",status="200"} 1\n'
+      );
+    });
+
+    it('should track different tag combinations separately', () => {
+      const reporter = new PrometheusReporter();
+      reporter.increment('requests', 1, { method: 'GET' });
+      reporter.increment('requests', 2, { method: 'POST' });
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP requests Counter metric\n' +
+        '# TYPE requests counter\n' +
+        'requests_total{method="GET"} 1\n' +
+        'requests_total{method="POST"} 2\n'
+      );
+    });
+
+    it('should handle increment with default value of 1', () => {
+      const reporter = new PrometheusReporter();
+      reporter.increment('test_counter');
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP test_counter Counter metric\n' +
+        '# TYPE test_counter counter\n' +
+        'test_counter_total 1\n'
+      );
+    });
+  });
+
+  describe('value (gauge)', () => {
+    it('should track gauge metrics', () => {
+      const reporter = new PrometheusReporter();
+      reporter.value('memory_usage', 1024);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP memory_usage Gauge metric\n' +
+        '# TYPE memory_usage gauge\n' +
+        'memory_usage 1024\n'
+      );
+    });
+
+    it('should update gauge values (not accumulate)', () => {
+      const reporter = new PrometheusReporter();
+      reporter.value('memory_usage', 1024);
+      reporter.value('memory_usage', 2048);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP memory_usage Gauge metric\n' +
+        '# TYPE memory_usage gauge\n' +
+        'memory_usage 2048\n'
+      );
+    });
+
+    it('should handle gauge with tags', () => {
+      const reporter = new PrometheusReporter();
+      reporter.value('temperature', 23.5, { location: 'server_room' });
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP temperature Gauge metric\n' +
+        '# TYPE temperature gauge\n' +
+        'temperature{location="server_room"} 23.5\n'
+      );
+    });
+  });
+
+  describe('report (histogram)', () => {
+    it('should track histogram metrics with default buckets', () => {
+      const reporter = new PrometheusReporter();
+      reporter.report('response_time', 150);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP response_time Histogram metric\n' +
+        '# TYPE response_time histogram\n' +
+        'response_time_bucket{le="10"} 0\n' +
+        'response_time_bucket{le="50"} 0\n' +
+        'response_time_bucket{le="100"} 0\n' +
+        'response_time_bucket{le="250"} 1\n' +
+        'response_time_bucket{le="500"} 1\n' +
+        'response_time_bucket{le="1000"} 1\n' +
+        'response_time_bucket{le="2500"} 1\n' +
+        'response_time_bucket{le="5000"} 1\n' +
+        'response_time_bucket{le="10000"} 1\n' +
+        'response_time_bucket{le="+Inf"} 1\n' +
+        'response_time_sum 150\n' +
+        'response_time_count 1\n'
+      );
+    });
+
+    it('should accumulate histogram observations correctly', () => {
+      const reporter = new PrometheusReporter();
+      reporter.report('response_time', 50);  // Goes in 50, 100, etc buckets
+      reporter.report('response_time', 150); // Goes in 250, 500, etc buckets
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP response_time Histogram metric\n' +
+        '# TYPE response_time histogram\n' +
+        'response_time_bucket{le="10"} 0\n' +
+        'response_time_bucket{le="50"} 1\n' +
+        'response_time_bucket{le="100"} 1\n' +
+        'response_time_bucket{le="250"} 2\n' +
+        'response_time_bucket{le="500"} 2\n' +
+        'response_time_bucket{le="1000"} 2\n' +
+        'response_time_bucket{le="2500"} 2\n' +
+        'response_time_bucket{le="5000"} 2\n' +
+        'response_time_bucket{le="10000"} 2\n' +
+        'response_time_bucket{le="+Inf"} 2\n' +
+        'response_time_sum 200\n' +
+        'response_time_count 2\n'
+      );
+    });
+
+    it('should handle histogram with custom buckets', () => {
+      const reporter = new PrometheusReporter({
+        buckets: [1, 5, 10]
+      });
+      reporter.report('custom_metric', 3);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP custom_metric Histogram metric\n' +
+        '# TYPE custom_metric histogram\n' +
+        'custom_metric_bucket{le="1"} 0\n' +
+        'custom_metric_bucket{le="5"} 1\n' +
+        'custom_metric_bucket{le="10"} 1\n' +
+        'custom_metric_bucket{le="+Inf"} 1\n' +
+        'custom_metric_sum 3\n' +
+        'custom_metric_count 1\n'
+      );
+    });
+  });
+
+  describe('soft limit behavior', () => {
+    it('should reset metrics after scrape when soft limit exceeded', () => {
+      const reporter = new PrometheusReporter({ softLimit: 2 });
+      
+      // Add metrics beyond soft limit
+      reporter.increment('metric1', 1);
+      reporter.increment('metric2', 1);
+      reporter.increment('metric3', 1);
+      
+      // First scrape should return all metrics
+      const output1 = reporter.getMetrics();
+      const expectedOutput1 = 
+        '# HELP metric1 Counter metric\n' +
+        '# TYPE metric1 counter\n' +
+        'metric1_total 1\n' +
+        '# HELP metric2 Counter metric\n' +
+        '# TYPE metric2 counter\n' +
+        'metric2_total 1\n' +
+        '# HELP metric3 Counter metric\n' +
+        '# TYPE metric3 counter\n' +
+        'metric3_total 1\n';
+      
+      expect(output1).toBe(expectedOutput1);
+      
+      // Second scrape should be empty (metrics were reset)
+      const output2 = reporter.getMetrics();
+      expect(output2).toBe('');
+    });
+
+    it('should not reset metrics when under soft limit', () => {
+      const reporter = new PrometheusReporter({ softLimit: 5 });
+      
+      reporter.increment('metric1', 1);
+      reporter.increment('metric2', 1);
+      
+      const output1 = reporter.getMetrics();
+      const output2 = reporter.getMetrics();
+      
+      // Should be the same both times
+      const expectedOutput = 
+        '# HELP metric1 Counter metric\n' +
+        '# TYPE metric1 counter\n' +
+        'metric1_total 1\n' +
+        '# HELP metric2 Counter metric\n' +
+        '# TYPE metric2 counter\n' +
+        'metric2_total 1\n';
+      
+      expect(output1).toBe(expectedOutput);
+      expect(output2).toBe(expectedOutput);
+    });
+  });
+
+  describe('hard limit behavior', () => {
+    it('should force reset when hard limit exceeded during metric update', () => {
+      const reporter = new PrometheusReporter({ hardLimit: 2 });
+      
+      // Add metrics up to hard limit
+      reporter.increment('metric1', 1);
+      reporter.increment('metric2', 1);
+      
+      // Adding one more should trigger hard reset
+      reporter.increment('metric3', 1);
+      
+      // Should only have the last metric
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP metric3 Counter metric\n' +
+        '# TYPE metric3 counter\n' +
+        'metric3_total 1\n'
+      );
+    });
+
+    it('should not trigger hard limit for existing metrics', () => {
+      const reporter = new PrometheusReporter({ hardLimit: 2 });
+      
+      // Add metrics up to hard limit
+      reporter.increment('metric1', 1);
+      reporter.increment('metric2', 1);
+      
+      // Updating existing metric should not trigger reset
+      reporter.increment('metric1', 5);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP metric1 Counter metric\n' +
+        '# TYPE metric1 counter\n' +
+        'metric1_total 6\n' +
+        '# HELP metric2 Counter metric\n' +
+        '# TYPE metric2 counter\n' +
+        'metric2_total 1\n'
+      );
+    });
+  });
+
+  describe('prefix', () => {
+    it('should add prefix to metric names', () => {
+      const reporter = new PrometheusReporter({ prefix: 'myapp_' });
+      reporter.increment('requests', 1);
+      
+      const output = reporter.getMetrics();
+      expect(output).toBe(
+        '# HELP myapp_requests Counter metric\n' +
+        '# TYPE myapp_requests counter\n' +
+        'myapp_requests_total 1\n'
+      );
+    });
+  });
+
+  describe('mixed metric types', () => {
+    it('should handle multiple metric types correctly', () => {
+      const reporter = new PrometheusReporter();
+      reporter.increment('http_requests', 10);
+      reporter.value('memory_usage', 1024);
+      reporter.report('response_time', 150);
+      
+      const output = reporter.getMetrics();
+      const expectedOutput = 
+        '# HELP http_requests Counter metric\n' +
+        '# TYPE http_requests counter\n' +
+        'http_requests_total 10\n' +
+        '# HELP memory_usage Gauge metric\n' +
+        '# TYPE memory_usage gauge\n' +
+        'memory_usage 1024\n' +
+        '# HELP response_time Histogram metric\n' +
+        '# TYPE response_time histogram\n' +
+        'response_time_bucket{le="10"} 0\n' +
+        'response_time_bucket{le="50"} 0\n' +
+        'response_time_bucket{le="100"} 0\n' +
+        'response_time_bucket{le="250"} 1\n' +
+        'response_time_bucket{le="500"} 1\n' +
+        'response_time_bucket{le="1000"} 1\n' +
+        'response_time_bucket{le="2500"} 1\n' +
+        'response_time_bucket{le="5000"} 1\n' +
+        'response_time_bucket{le="10000"} 1\n' +
+        'response_time_bucket{le="+Inf"} 1\n' +
+        'response_time_sum 150\n' +
+        'response_time_count 1\n';
+      
+      expect(output).toBe(expectedOutput);
+    });
+  });
+});

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,4 @@
 export * from "./reporter";
 export * from "./tags";
 export * from './error-callback';
+export * from './log-event';

--- a/src/types/log-event.d.ts
+++ b/src/types/log-event.d.ts
@@ -1,0 +1,18 @@
+export type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+
+export type LogEventCode = 
+  | 'HARD_LIMIT_REACHED'      // Emergency reset triggered
+  | 'SOFT_LIMIT_EXCEEDED'     // Soft reset after scrape
+  | 'APPROACHING_SOFT_LIMIT'  // Warning threshold reached
+  | 'METRICS_RESET';          // Metrics were reset
+
+export interface LogEvent {
+  level: LogLevel;
+  code: LogEventCode;
+  message: string;
+  params?: Record<string, any>;
+  timestamp: number;
+  reporter?: string;  // Name of the reporter that generated the event
+}
+
+export type LogCallback = (event: LogEvent) => void;


### PR DESCRIPTION
Add a reporter for Prometheus with zero external dependencies, and resilience in mind:
* Double threshold strategy - soft and hard limits for reseting the scraped buffer, both configurable with sensible defaults
* Initial support for structured logging. Might be expanded to the other reporters
* Follow Prometheus formatting guidelines.
* Example for running locally - with docker-compose

This will be considered experimental until it will be used by an actual system